### PR TITLE
Remove creator from SiteView

### DIFF
--- a/src/interfaces/views.ts
+++ b/src/interfaces/views.ts
@@ -57,7 +57,6 @@ export interface LocalUserSettingsView {
 
 export interface SiteView {
   site: Site;
-  creator: PersonSafe;
   counts: SiteAggregates;
 }
 


### PR DESCRIPTION
It was removed from the API: https://github.com/LemmyNet/lemmy/blob/dd5835fb6ee210af78ba876bf3e9f37ea1db521b/crates/db_views/src/site_view.rs#L10

@LouisMarotta has found this inconsistency 