### PR TITLE
feat: add image upload method to http client

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,10 @@
     ]
   },
   "dependencies": {
-    "node-fetch": "2.6.6"
+    "node-fetch": "^3.3.1"
   },
   "devDependencies": {
     "@types/node": "^18.6.2",
-    "@types/node-fetch": "2.6.2",
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
     "eslint": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     ]
   },
   "dependencies": {
-    "node-fetch": "^3.3.1"
+    "cross-fetch": "^3.1.5",
+    "form-data": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^18.6.2",

--- a/src/http.ts
+++ b/src/http.ts
@@ -168,7 +168,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /site`
    */
-  async getSite(form: GetSite) {
+  getSite(form: GetSite) {
     return this.wrapper<GetSite, GetSiteResponse>(HttpType.Get, "/site", form);
   }
 
@@ -177,7 +177,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /site`
    */
-  async createSite(form: CreateSite) {
+  createSite(form: CreateSite) {
     return this.wrapper<CreateSite, SiteResponse>(HttpType.Post, "/site", form);
   }
 
@@ -186,7 +186,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /site`
    */
-  async editSite(form: EditSite) {
+  editSite(form: EditSite) {
     return this.wrapper<EditSite, SiteResponse>(HttpType.Put, "/site", form);
   }
 
@@ -195,7 +195,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/leave_admin`
    */
-  async leaveAdmin(form: LeaveAdmin) {
+  leaveAdmin(form: LeaveAdmin) {
     return this.wrapper<LeaveAdmin, GetSiteResponse>(
       HttpType.Post,
       "/user/leave_admin",
@@ -208,7 +208,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /modlog`
    */
-  async getModlog(form: GetModlog) {
+  getModlog(form: GetModlog) {
     return this.wrapper<GetModlog, GetModlogResponse>(
       HttpType.Get,
       "/modlog",
@@ -221,7 +221,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /search`
    */
-  async search(form: Search) {
+  search(form: Search) {
     return this.wrapper<Search, SearchResponse>(HttpType.Get, "/search", form);
   }
 
@@ -230,7 +230,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /resolve_object`
    */
-  async resolveObject(form: ResolveObject) {
+  resolveObject(form: ResolveObject) {
     return this.wrapper<ResolveObject, ResolveObjectResponse>(
       HttpType.Get,
       "/resolve_object",
@@ -243,7 +243,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community`
    */
-  async createCommunity(form: CreateCommunity) {
+  createCommunity(form: CreateCommunity) {
     return this.wrapper<CreateCommunity, CommunityResponse>(
       HttpType.Post,
       "/community",
@@ -256,7 +256,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /community`
    */
-  async getCommunity(form: GetCommunity) {
+  getCommunity(form: GetCommunity) {
     return this.wrapper<GetCommunity, GetCommunityResponse>(
       HttpType.Get,
       "/community",
@@ -269,7 +269,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /community`
    */
-  async editCommunity(form: EditCommunity) {
+  editCommunity(form: EditCommunity) {
     return this.wrapper<EditCommunity, CommunityResponse>(
       HttpType.Put,
       "/community",
@@ -282,7 +282,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /community/list`
    */
-  async listCommunities(form: ListCommunities) {
+  listCommunities(form: ListCommunities) {
     return this.wrapper<ListCommunities, ListCommunitiesResponse>(
       HttpType.Get,
       "/community/list",
@@ -295,7 +295,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/follow`
    */
-  async followCommunity(form: FollowCommunity) {
+  followCommunity(form: FollowCommunity) {
     return this.wrapper<FollowCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/follow",
@@ -308,7 +308,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/block`
    */
-  async blockCommunity(form: BlockCommunity) {
+  blockCommunity(form: BlockCommunity) {
     return this.wrapper<BlockCommunity, BlockCommunityResponse>(
       HttpType.Post,
       "/community/block",
@@ -321,7 +321,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/delete`
    */
-  async deleteCommunity(form: DeleteCommunity) {
+  deleteCommunity(form: DeleteCommunity) {
     return this.wrapper<DeleteCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/delete",
@@ -334,7 +334,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/remove`
    */
-  async removeCommunity(form: RemoveCommunity) {
+  removeCommunity(form: RemoveCommunity) {
     return this.wrapper<RemoveCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/remove",
@@ -347,7 +347,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/transfer`
    */
-  async transferCommunity(form: TransferCommunity) {
+  transferCommunity(form: TransferCommunity) {
     return this.wrapper<TransferCommunity, GetCommunityResponse>(
       HttpType.Post,
       "/community/transfer",
@@ -360,7 +360,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/ban_user`
    */
-  async banFromCommunity(form: BanFromCommunity) {
+  banFromCommunity(form: BanFromCommunity) {
     return this.wrapper<BanFromCommunity, BanFromCommunityResponse>(
       HttpType.Post,
       "/community/ban_user",
@@ -373,7 +373,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/mod`
    */
-  async addModToCommunity(form: AddModToCommunity) {
+  addModToCommunity(form: AddModToCommunity) {
     return this.wrapper<AddModToCommunity, AddModToCommunityResponse>(
       HttpType.Post,
       "/community/mod",
@@ -386,7 +386,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post`
    */
-  async createPost(form: CreatePost) {
+  createPost(form: CreatePost) {
     return this.wrapper<CreatePost, PostResponse>(HttpType.Post, "/post", form);
   }
 
@@ -395,7 +395,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /post`
    */
-  async getPost(form: GetPost) {
+  getPost(form: GetPost) {
     return this.wrapper<GetPost, GetPostResponse>(HttpType.Get, "/post", form);
   }
 
@@ -404,7 +404,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /post`
    */
-  async editPost(form: EditPost) {
+  editPost(form: EditPost) {
     return this.wrapper<EditPost, PostResponse>(HttpType.Put, "/post", form);
   }
 
@@ -413,7 +413,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/delete`
    */
-  async deletePost(form: DeletePost) {
+  deletePost(form: DeletePost) {
     return this.wrapper<DeletePost, PostResponse>(
       HttpType.Post,
       "/post/delete",
@@ -426,7 +426,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/remove`
    */
-  async removePost(form: RemovePost) {
+  removePost(form: RemovePost) {
     return this.wrapper<RemovePost, PostResponse>(
       HttpType.Post,
       "/post/remove",
@@ -439,7 +439,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/mark_as_read`
    */
-  async markPostAsRead(form: MarkPostAsRead) {
+  markPostAsRead(form: MarkPostAsRead) {
     return this.wrapper<MarkPostAsRead, PostResponse>(
       HttpType.Post,
       "/post/mark_as_read",
@@ -452,7 +452,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/lock`
    */
-  async lockPost(form: LockPost) {
+  lockPost(form: LockPost) {
     return this.wrapper<LockPost, PostResponse>(
       HttpType.Post,
       "/post/lock",
@@ -465,7 +465,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/feature`
    */
-  async featurePost(form: FeaturePost) {
+  featurePost(form: FeaturePost) {
     return this.wrapper<FeaturePost, PostResponse>(
       HttpType.Post,
       "/post/feature",
@@ -478,7 +478,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /post/list`
    */
-  async getPosts(form: GetPosts) {
+  getPosts(form: GetPosts) {
     return this.wrapper<GetPosts, GetPostsResponse>(
       HttpType.Get,
       "/post/list",
@@ -491,7 +491,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/like`
    */
-  async likePost(form: CreatePostLike) {
+  likePost(form: CreatePostLike) {
     return this.wrapper<CreatePostLike, PostResponse>(
       HttpType.Post,
       "/post/like",
@@ -504,7 +504,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /post/save`
    */
-  async savePost(form: SavePost) {
+  savePost(form: SavePost) {
     return this.wrapper<SavePost, PostResponse>(
       HttpType.Put,
       "/post/save",
@@ -517,7 +517,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/report`
    */
-  async createPostReport(form: CreatePostReport) {
+  createPostReport(form: CreatePostReport) {
     return this.wrapper<CreatePostReport, PostReportResponse>(
       HttpType.Post,
       "/post/report",
@@ -530,7 +530,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /post/report/resolve`
    */
-  async resolvePostReport(form: ResolvePostReport) {
+  resolvePostReport(form: ResolvePostReport) {
     return this.wrapper<ResolvePostReport, PostReportResponse>(
       HttpType.Put,
       "/post/report/resolve",
@@ -543,7 +543,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /post/report/list`
    */
-  async listPostReports(form: ListPostReports) {
+  listPostReports(form: ListPostReports) {
     return this.wrapper<ListPostReports, ListPostReportsResponse>(
       HttpType.Get,
       "/post/report/list",
@@ -556,7 +556,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /post/site_metadata`
    */
-  async getSiteMetadata(form: GetSiteMetadata) {
+  getSiteMetadata(form: GetSiteMetadata) {
     return this.wrapper<GetSiteMetadata, GetSiteMetadataResponse>(
       HttpType.Get,
       "/post/site_metadata",
@@ -569,7 +569,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment`
    */
-  async createComment(form: CreateComment) {
+  createComment(form: CreateComment) {
     return this.wrapper<CreateComment, CommentResponse>(
       HttpType.Post,
       "/comment",
@@ -582,7 +582,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /comment`
    */
-  async editComment(form: EditComment) {
+  editComment(form: EditComment) {
     return this.wrapper<EditComment, CommentResponse>(
       HttpType.Put,
       "/comment",
@@ -595,7 +595,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/delete`
    */
-  async deleteComment(form: DeleteComment) {
+  deleteComment(form: DeleteComment) {
     return this.wrapper<DeleteComment, CommentResponse>(
       HttpType.Post,
       "/comment/delete",
@@ -608,7 +608,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/remove`
    */
-  async removeComment(form: RemoveComment) {
+  removeComment(form: RemoveComment) {
     return this.wrapper<RemoveComment, CommentResponse>(
       HttpType.Post,
       "/comment/remove",
@@ -621,7 +621,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/mark_as_read`
    */
-  async markCommentReplyAsRead(form: MarkCommentReplyAsRead) {
+  markCommentReplyAsRead(form: MarkCommentReplyAsRead) {
     return this.wrapper<MarkCommentReplyAsRead, CommentResponse>(
       HttpType.Post,
       "/comment/mark_as_read",
@@ -634,7 +634,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/like`
    */
-  async likeComment(form: CreateCommentLike) {
+  likeComment(form: CreateCommentLike) {
     return this.wrapper<CreateCommentLike, CommentResponse>(
       HttpType.Post,
       "/comment/like",
@@ -647,7 +647,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /comment/save`
    */
-  async saveComment(form: SaveComment) {
+  saveComment(form: SaveComment) {
     return this.wrapper<SaveComment, CommentResponse>(
       HttpType.Put,
       "/comment/save",
@@ -660,7 +660,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /comment/list`
    */
-  async getComments(form: GetComments) {
+  getComments(form: GetComments) {
     return this.wrapper<GetComments, GetCommentsResponse>(
       HttpType.Get,
       "/comment/list",
@@ -673,7 +673,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/report`
    */
-  async createCommentReport(form: CreateCommentReport) {
+  createCommentReport(form: CreateCommentReport) {
     return this.wrapper<CreateCommentReport, CommentReportResponse>(
       HttpType.Post,
       "/comment/report",
@@ -686,7 +686,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /comment/report/resolve`
    */
-  async resolveCommentReport(form: ResolveCommentReport) {
+  resolveCommentReport(form: ResolveCommentReport) {
     return this.wrapper<ResolveCommentReport, CommentReportResponse>(
       HttpType.Put,
       "/comment/report/resolve",
@@ -699,7 +699,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /comment/report/list`
    */
-  async listCommentReports(form: ListCommentReports) {
+  listCommentReports(form: ListCommentReports) {
     return this.wrapper<ListCommentReports, ListCommentReportsResponse>(
       HttpType.Get,
       "/comment/report/list",
@@ -712,7 +712,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /private_message/list`
    */
-  async getPrivateMessages(form: GetPrivateMessages) {
+  getPrivateMessages(form: GetPrivateMessages) {
     return this.wrapper<GetPrivateMessages, PrivateMessagesResponse>(
       HttpType.Get,
       "/private_message/list",
@@ -725,7 +725,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /private_message`
    */
-  async createPrivateMessage(form: CreatePrivateMessage) {
+  createPrivateMessage(form: CreatePrivateMessage) {
     return this.wrapper<CreatePrivateMessage, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message",
@@ -738,7 +738,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /private_message`
    */
-  async editPrivateMessage(form: EditPrivateMessage) {
+  editPrivateMessage(form: EditPrivateMessage) {
     return this.wrapper<EditPrivateMessage, PrivateMessageResponse>(
       HttpType.Put,
       "/private_message",
@@ -751,7 +751,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /private_message/delete`
    */
-  async deletePrivateMessage(form: DeletePrivateMessage) {
+  deletePrivateMessage(form: DeletePrivateMessage) {
     return this.wrapper<DeletePrivateMessage, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message/delete",
@@ -764,7 +764,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /private_message/mark_as_read`
    */
-  async markPrivateMessageAsRead(form: MarkPrivateMessageAsRead) {
+  markPrivateMessageAsRead(form: MarkPrivateMessageAsRead) {
     return this.wrapper<MarkPrivateMessageAsRead, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message/mark_as_read",
@@ -777,7 +777,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /private_message/report`
    */
-  async createPrivateMessageReport(form: CreatePrivateMessageReport) {
+  createPrivateMessageReport(form: CreatePrivateMessageReport) {
     return this.wrapper<
       CreatePrivateMessageReport,
       PrivateMessageReportResponse
@@ -789,7 +789,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /private_message/report/resolve`
    */
-  async resolvePrivateMessageReport(form: ResolvePrivateMessageReport) {
+  resolvePrivateMessageReport(form: ResolvePrivateMessageReport) {
     return this.wrapper<
       ResolvePrivateMessageReport,
       PrivateMessageReportResponse
@@ -801,7 +801,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /private_message/report/list`
    */
-  async listPrivateMessageReports(form: ListPrivateMessageReports) {
+  listPrivateMessageReports(form: ListPrivateMessageReports) {
     return this.wrapper<
       ListPrivateMessageReports,
       ListPrivateMessageReportsResponse
@@ -813,7 +813,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/register`
    */
-  async register(form: Register) {
+  register(form: Register) {
     return this.wrapper<Register, LoginResponse>(
       HttpType.Post,
       "/user/register",
@@ -826,7 +826,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/login`
    */
-  async login(form: Login) {
+  login(form: Login) {
     return this.wrapper<Login, LoginResponse>(
       HttpType.Post,
       "/user/login",
@@ -839,7 +839,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user`
    */
-  async getPersonDetails(form: GetPersonDetails) {
+  getPersonDetails(form: GetPersonDetails) {
     return this.wrapper<GetPersonDetails, GetPersonDetailsResponse>(
       HttpType.Get,
       "/user",
@@ -852,7 +852,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/mention`
    */
-  async getPersonMentions(form: GetPersonMentions) {
+  getPersonMentions(form: GetPersonMentions) {
     return this.wrapper<GetPersonMentions, GetPersonMentionsResponse>(
       HttpType.Get,
       "/user/mention",
@@ -865,7 +865,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/mention/mark_as_read`
    */
-  async markPersonMentionAsRead(form: MarkPersonMentionAsRead) {
+  markPersonMentionAsRead(form: MarkPersonMentionAsRead) {
     return this.wrapper<MarkPersonMentionAsRead, PersonMentionResponse>(
       HttpType.Post,
       "/user/mention/mark_as_read",
@@ -878,7 +878,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/replies`
    */
-  async getReplies(form: GetReplies) {
+  getReplies(form: GetReplies) {
     return this.wrapper<GetReplies, GetRepliesResponse>(
       HttpType.Get,
       "/user/replies",
@@ -891,7 +891,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/ban`
    */
-  async banPerson(form: BanPerson) {
+  banPerson(form: BanPerson) {
     return this.wrapper<BanPerson, BanPersonResponse>(
       HttpType.Post,
       "/user/ban",
@@ -904,7 +904,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/banned`
    */
-  async getBannedPersons(form: GetBannedPersons) {
+  getBannedPersons(form: GetBannedPersons) {
     return this.wrapper<GetBannedPersons, BannedPersonsResponse>(
       HttpType.Get,
       "/user/banned",
@@ -917,7 +917,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/block`
    */
-  async blockPerson(form: BlockPerson) {
+  blockPerson(form: BlockPerson) {
     return this.wrapper<BlockPerson, BlockPersonResponse>(
       HttpType.Post,
       "/user/block",
@@ -930,7 +930,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/get_captcha`
    */
-  async getCaptcha() {
+  getCaptcha() {
     return this.wrapper<any, GetCaptchaResponse>(
       HttpType.Get,
       "/user/get_captcha",
@@ -943,7 +943,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/delete_account`
    */
-  async deleteAccount(form: DeleteAccount) {
+  deleteAccount(form: DeleteAccount) {
     return this.wrapper<DeleteAccount, DeleteAccountResponse>(
       HttpType.Post,
       "/user/delete_account",
@@ -956,7 +956,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/password_reset`
    */
-  async passwordReset(form: PasswordReset) {
+  passwordReset(form: PasswordReset) {
     return this.wrapper<PasswordReset, PasswordResetResponse>(
       HttpType.Post,
       "/user/password_reset",
@@ -969,7 +969,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/password_change`
    */
-  async passwordChange(form: PasswordChange) {
+  passwordChange(form: PasswordChange) {
     return this.wrapper<PasswordChange, LoginResponse>(
       HttpType.Post,
       "/user/password_change",
@@ -982,7 +982,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/mark_all_as_read`
    */
-  async markAllAsRead(form: MarkAllAsRead) {
+  markAllAsRead(form: MarkAllAsRead) {
     return this.wrapper<MarkAllAsRead, GetRepliesResponse>(
       HttpType.Post,
       "/user/mark_all_as_read",
@@ -995,7 +995,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /user/save_user_settings`
    */
-  async saveUserSettings(form: SaveUserSettings) {
+  saveUserSettings(form: SaveUserSettings) {
     return this.wrapper<SaveUserSettings, LoginResponse>(
       HttpType.Put,
       "/user/save_user_settings",
@@ -1008,7 +1008,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /user/change_password`
    */
-  async changePassword(form: ChangePassword) {
+  changePassword(form: ChangePassword) {
     return this.wrapper<ChangePassword, LoginResponse>(
       HttpType.Put,
       "/user/change_password",
@@ -1021,7 +1021,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/report_count`
    */
-  async getReportCount(form: GetReportCount) {
+  getReportCount(form: GetReportCount) {
     return this.wrapper<GetReportCount, GetReportCountResponse>(
       HttpType.Get,
       "/user/report_count",
@@ -1034,7 +1034,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/unread_count`
    */
-  async getUnreadCount(form: GetUnreadCount) {
+  getUnreadCount(form: GetUnreadCount) {
     return this.wrapper<GetUnreadCount, GetUnreadCountResponse>(
       HttpType.Get,
       "/user/unread_count",
@@ -1047,7 +1047,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/verify_email`
    */
-  async verifyEmail(form: VerifyEmail) {
+  verifyEmail(form: VerifyEmail) {
     return this.wrapper<VerifyEmail, VerifyEmailResponse>(
       HttpType.Post,
       "/user/verify_email",
@@ -1060,7 +1060,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/add`
    */
-  async addAdmin(form: AddAdmin) {
+  addAdmin(form: AddAdmin) {
     return this.wrapper<AddAdmin, AddAdminResponse>(
       HttpType.Post,
       "/admin/add",
@@ -1073,7 +1073,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /admin/registration_application/count`
    */
-  async getUnreadRegistrationApplicationCount(
+  getUnreadRegistrationApplicationCount(
     form: GetUnreadRegistrationApplicationCount
   ) {
     return this.wrapper<
@@ -1087,7 +1087,7 @@ export class LemmyHttp {
    *
    * `HTTP.GET /admin/registration_application/list`
    */
-  async listRegistrationApplications(form: ListRegistrationApplications) {
+  listRegistrationApplications(form: ListRegistrationApplications) {
     return this.wrapper<
       ListRegistrationApplications,
       ListRegistrationApplicationsResponse
@@ -1099,7 +1099,7 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /admin/registration_application/approve`
    */
-  async approveRegistrationApplication(form: ApproveRegistrationApplication) {
+  approveRegistrationApplication(form: ApproveRegistrationApplication) {
     return this.wrapper<
       ApproveRegistrationApplication,
       RegistrationApplicationResponse
@@ -1111,7 +1111,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/purge/person`
    */
-  async purgePerson(form: PurgePerson) {
+  purgePerson(form: PurgePerson) {
     return this.wrapper<PurgePerson, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/person",
@@ -1124,7 +1124,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/purge/community`
    */
-  async purgeCommunity(form: PurgeCommunity) {
+  purgeCommunity(form: PurgeCommunity) {
     return this.wrapper<PurgeCommunity, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/community",
@@ -1137,7 +1137,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/purge/post`
    */
-  async purgePost(form: PurgePost) {
+  purgePost(form: PurgePost) {
     return this.wrapper<PurgePost, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/post",
@@ -1150,7 +1150,7 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/purge/comment`
    */
-  async purgeComment(form: PurgeComment) {
+  purgeComment(form: PurgeComment) {
     return this.wrapper<PurgeComment, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/comment",
@@ -1165,7 +1165,7 @@ export class LemmyHttp {
     image,
     auth,
   }: UploadImage): Promise<UploadImageResponse> {
-    const formData = await createFormData(image);
+    const formData = createFormData(image);
 
     // If jwt cookie not already set by browser, set it with passed in auth
     const headers = {} as any;
@@ -1242,9 +1242,7 @@ function encodeGetParams<BodyType extends object>(p: BodyType): string {
     .join("&");
 }
 
-async function createFormData(
-  image: globalThis.File | Buffer
-): Promise<FormData> {
+function createFormData(image: File | Buffer): FormData {
   let formData = new FormData();
 
   if (image.constructor.name === "File") {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1246,7 +1246,7 @@ function encodeGetParams<BodyType extends object>(p: BodyType): string {
     .join("&");
 }
 
-async function createFormData(image: Blob | Buffer): Promise<FormData> {
+async function createFormData(image: File | Buffer): Promise<FormData> {
   const file = await createFile(image);
   let formData: FormData;
 
@@ -1267,7 +1267,7 @@ async function createFormData(image: Blob | Buffer): Promise<FormData> {
 // smart enough to figure out the filetype without looking at the file extension.
 const imageFileName = "image.jpg";
 
-async function createFile(image: Blob | Buffer): Promise<File> {
+async function createFile(image: File | Buffer): Promise<File> {
   let file = image;
 
   if (file.constructor.name !== "File") {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1287,8 +1287,8 @@ async function createFormData(image: Blob | Buffer) {
 }
 
 // The File constructor needs a filename to make a new file, but it doesn't actually
-// effect the name or for a name and is smart enough to figure out the filetype without
-// looking at the file extension.
+// effect the name or filetype: pictrs generates a random value for a name and is
+// smart enough to figure out the filetype without looking at the file extension.
 const imageFileName = "image.jpg";
 
 async function createFile(image: Blob | Buffer) {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1218,7 +1218,7 @@ export class LemmyHttp {
 
     const responseJson = await response.json();
 
-    if (responseJson.msg == "ok") {
+    if (responseJson.msg === "ok") {
       const { file: hash, delete_token: deleteToken } = responseJson.files[0];
       delete_url = `${this.pictrsUrl}/delete/${deleteToken}/${hash}`;
       url = `${this.pictrsUrl}/${hash}`;
@@ -1240,7 +1240,7 @@ export class LemmyHttp {
     endpoint: string,
     form: BodyType
   ): Promise<ResponseType> {
-    if (type_ == HttpType.Get) {
+    if (type_ === HttpType.Get) {
       const getUrl = `${this.buildFullUrl(endpoint)}?${encodeGetParams(form)}`;
       const response = await fetch(getUrl, {
         method: HttpType.Get,

--- a/src/http.ts
+++ b/src/http.ts
@@ -1172,11 +1172,12 @@ export class LemmyHttp {
     const formData = await createFormData(image);
 
     // If jwt cookie not already set by browser, set it with passed in auth
-    let headers: Record<string, string> | undefined = undefined;
-    if (!globalThis?.document?.cookie?.includes("jwt=")) {
-      headers = {
-        Cookie: `jwt=${auth}`,
-      };
+    const headers = {} as any;
+    if (
+      !globalThis?.document?.cookie?.includes("jwt=") &&
+      !this.headers?.Cookie?.includes("jwt=")
+    ) {
+      headers.Cookie = `jwt=${auth}`;
     }
 
     let url: string | undefined = undefined;
@@ -1185,7 +1186,10 @@ export class LemmyHttp {
     const response = await fetch(this.pictrsUrl, {
       method: HttpType.Post,
       body: formData,
-      headers,
+      headers: {
+        ...this.headers,
+        ...headers,
+      },
     });
 
     const responseJson = await response.json();

--- a/src/http.ts
+++ b/src/http.ts
@@ -1242,7 +1242,7 @@ function encodeGetParams<BodyType extends object>(p: BodyType): string {
     .join("&");
 }
 
-async function createFormData(image: Blob | Buffer) {
+async function createFormData(image: Blob | Buffer): Promise<FormData> {
   const file = await createFile(image);
   let formData: FormData;
 
@@ -1263,7 +1263,7 @@ async function createFormData(image: Blob | Buffer) {
 // smart enough to figure out the filetype without looking at the file extension.
 const imageFileName = "image.jpg";
 
-async function createFile(image: Blob | Buffer) {
+async function createFile(image: Blob | Buffer): Promise<File> {
   let file = image;
 
   if (file.constructor.name !== "File") {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,4 +1,12 @@
-import fetch from "node-fetch";
+const fetch: typeof globalThis.fetch = async (...args) => {
+  if (globalThis?.fetch) {
+    return await globalThis.fetch(...args);
+  } else {
+    const nodeFetch = (await dynamicImport("node-fetch")).default;
+    return await nodeFetch(...args);
+  }
+};
+
 import {
   CommentReportResponse,
   CommentResponse,
@@ -131,7 +139,8 @@ import {
   SearchResponse,
   SiteResponse,
 } from "./interfaces/api/site";
-import { VERSION } from "./interfaces/others";
+import { UploadImage, UploadImageResponse, VERSION } from "./interfaces/others";
+import { dynamicImport } from "./utils";
 
 enum HttpType {
   Get = "GET",
@@ -145,6 +154,7 @@ enum HttpType {
 export class LemmyHttp {
   private apiUrl: string;
   private headers: { [key: string]: string } = {};
+  private pictrsUrl: string;
 
   /**
    * Generates a new instance of LemmyHttp.
@@ -153,6 +163,7 @@ export class LemmyHttp {
    */
   constructor(baseUrl: string, headers?: { [key: string]: string }) {
     this.apiUrl = `${baseUrl}/api/${VERSION}`;
+    this.pictrsUrl = `${baseUrl}/pictrs/image`;
 
     if (headers) {
       this.headers = headers;
@@ -165,7 +176,11 @@ export class LemmyHttp {
    * `HTTP.GET /site`
    */
   async getSite(form: GetSite) {
-    return this.wrapper<GetSite, GetSiteResponse>(HttpType.Get, "/site", form);
+    return await this.wrapper<GetSite, GetSiteResponse>(
+      HttpType.Get,
+      "/site",
+      form
+    );
   }
 
   /**
@@ -174,7 +189,11 @@ export class LemmyHttp {
    * `HTTP.POST /site`
    */
   async createSite(form: CreateSite) {
-    return this.wrapper<CreateSite, SiteResponse>(HttpType.Post, "/site", form);
+    return await this.wrapper<CreateSite, SiteResponse>(
+      HttpType.Post,
+      "/site",
+      form
+    );
   }
 
   /**
@@ -183,7 +202,11 @@ export class LemmyHttp {
    * `HTTP.PUT /site`
    */
   async editSite(form: EditSite) {
-    return this.wrapper<EditSite, SiteResponse>(HttpType.Put, "/site", form);
+    return await this.wrapper<EditSite, SiteResponse>(
+      HttpType.Put,
+      "/site",
+      form
+    );
   }
 
   /**
@@ -192,7 +215,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/leave_admin`
    */
   async leaveAdmin(form: LeaveAdmin) {
-    return this.wrapper<LeaveAdmin, GetSiteResponse>(
+    return await this.wrapper<LeaveAdmin, GetSiteResponse>(
       HttpType.Post,
       "/user/leave_admin",
       form
@@ -205,7 +228,7 @@ export class LemmyHttp {
    * `HTTP.GET /modlog`
    */
   async getModlog(form: GetModlog) {
-    return this.wrapper<GetModlog, GetModlogResponse>(
+    return await this.wrapper<GetModlog, GetModlogResponse>(
       HttpType.Get,
       "/modlog",
       form
@@ -218,7 +241,11 @@ export class LemmyHttp {
    * `HTTP.GET /search`
    */
   async search(form: Search) {
-    return this.wrapper<Search, SearchResponse>(HttpType.Get, "/search", form);
+    return await this.wrapper<Search, SearchResponse>(
+      HttpType.Get,
+      "/search",
+      form
+    );
   }
 
   /**
@@ -227,7 +254,7 @@ export class LemmyHttp {
    * `HTTP.GET /resolve_object`
    */
   async resolveObject(form: ResolveObject) {
-    return this.wrapper<ResolveObject, ResolveObjectResponse>(
+    return await this.wrapper<ResolveObject, ResolveObjectResponse>(
       HttpType.Get,
       "/resolve_object",
       form
@@ -240,7 +267,7 @@ export class LemmyHttp {
    * `HTTP.POST /community`
    */
   async createCommunity(form: CreateCommunity) {
-    return this.wrapper<CreateCommunity, CommunityResponse>(
+    return await this.wrapper<CreateCommunity, CommunityResponse>(
       HttpType.Post,
       "/community",
       form
@@ -253,7 +280,7 @@ export class LemmyHttp {
    * `HTTP.GET /community`
    */
   async getCommunity(form: GetCommunity) {
-    return this.wrapper<GetCommunity, GetCommunityResponse>(
+    return await this.wrapper<GetCommunity, GetCommunityResponse>(
       HttpType.Get,
       "/community",
       form
@@ -266,7 +293,7 @@ export class LemmyHttp {
    * `HTTP.PUT /community`
    */
   async editCommunity(form: EditCommunity) {
-    return this.wrapper<EditCommunity, CommunityResponse>(
+    return await this.wrapper<EditCommunity, CommunityResponse>(
       HttpType.Put,
       "/community",
       form
@@ -279,7 +306,7 @@ export class LemmyHttp {
    * `HTTP.GET /community/list`
    */
   async listCommunities(form: ListCommunities) {
-    return this.wrapper<ListCommunities, ListCommunitiesResponse>(
+    return await this.wrapper<ListCommunities, ListCommunitiesResponse>(
       HttpType.Get,
       "/community/list",
       form
@@ -292,7 +319,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/follow`
    */
   async followCommunity(form: FollowCommunity) {
-    return this.wrapper<FollowCommunity, CommunityResponse>(
+    return await this.wrapper<FollowCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/follow",
       form
@@ -305,7 +332,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/block`
    */
   async blockCommunity(form: BlockCommunity) {
-    return this.wrapper<BlockCommunity, BlockCommunityResponse>(
+    return await this.wrapper<BlockCommunity, BlockCommunityResponse>(
       HttpType.Post,
       "/community/block",
       form
@@ -318,7 +345,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/delete`
    */
   async deleteCommunity(form: DeleteCommunity) {
-    return this.wrapper<DeleteCommunity, CommunityResponse>(
+    return await this.wrapper<DeleteCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/delete",
       form
@@ -331,7 +358,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/remove`
    */
   async removeCommunity(form: RemoveCommunity) {
-    return this.wrapper<RemoveCommunity, CommunityResponse>(
+    return await this.wrapper<RemoveCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/remove",
       form
@@ -344,7 +371,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/transfer`
    */
   async transferCommunity(form: TransferCommunity) {
-    return this.wrapper<TransferCommunity, GetCommunityResponse>(
+    return await this.wrapper<TransferCommunity, GetCommunityResponse>(
       HttpType.Post,
       "/community/transfer",
       form
@@ -357,7 +384,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/ban_user`
    */
   async banFromCommunity(form: BanFromCommunity) {
-    return this.wrapper<BanFromCommunity, BanFromCommunityResponse>(
+    return await this.wrapper<BanFromCommunity, BanFromCommunityResponse>(
       HttpType.Post,
       "/community/ban_user",
       form
@@ -370,7 +397,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/mod`
    */
   async addModToCommunity(form: AddModToCommunity) {
-    return this.wrapper<AddModToCommunity, AddModToCommunityResponse>(
+    return await this.wrapper<AddModToCommunity, AddModToCommunityResponse>(
       HttpType.Post,
       "/community/mod",
       form
@@ -383,7 +410,11 @@ export class LemmyHttp {
    * `HTTP.POST /post`
    */
   async createPost(form: CreatePost) {
-    return this.wrapper<CreatePost, PostResponse>(HttpType.Post, "/post", form);
+    return await this.wrapper<CreatePost, PostResponse>(
+      HttpType.Post,
+      "/post",
+      form
+    );
   }
 
   /**
@@ -392,7 +423,11 @@ export class LemmyHttp {
    * `HTTP.GET /post`
    */
   async getPost(form: GetPost) {
-    return this.wrapper<GetPost, GetPostResponse>(HttpType.Get, "/post", form);
+    return await this.wrapper<GetPost, GetPostResponse>(
+      HttpType.Get,
+      "/post",
+      form
+    );
   }
 
   /**
@@ -401,7 +436,11 @@ export class LemmyHttp {
    * `HTTP.PUT /post`
    */
   async editPost(form: EditPost) {
-    return this.wrapper<EditPost, PostResponse>(HttpType.Put, "/post", form);
+    return await this.wrapper<EditPost, PostResponse>(
+      HttpType.Put,
+      "/post",
+      form
+    );
   }
 
   /**
@@ -410,7 +449,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/delete`
    */
   async deletePost(form: DeletePost) {
-    return this.wrapper<DeletePost, PostResponse>(
+    return await this.wrapper<DeletePost, PostResponse>(
       HttpType.Post,
       "/post/delete",
       form
@@ -423,7 +462,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/remove`
    */
   async removePost(form: RemovePost) {
-    return this.wrapper<RemovePost, PostResponse>(
+    return await this.wrapper<RemovePost, PostResponse>(
       HttpType.Post,
       "/post/remove",
       form
@@ -436,7 +475,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/mark_as_read`
    */
   async markPostAsRead(form: MarkPostAsRead) {
-    return this.wrapper<MarkPostAsRead, PostResponse>(
+    return await this.wrapper<MarkPostAsRead, PostResponse>(
       HttpType.Post,
       "/post/mark_as_read",
       form
@@ -449,7 +488,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/lock`
    */
   async lockPost(form: LockPost) {
-    return this.wrapper<LockPost, PostResponse>(
+    return await this.wrapper<LockPost, PostResponse>(
       HttpType.Post,
       "/post/lock",
       form
@@ -462,7 +501,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/feature`
    */
   async featurePost(form: FeaturePost) {
-    return this.wrapper<FeaturePost, PostResponse>(
+    return await this.wrapper<FeaturePost, PostResponse>(
       HttpType.Post,
       "/post/feature",
       form
@@ -475,7 +514,7 @@ export class LemmyHttp {
    * `HTTP.GET /post/list`
    */
   async getPosts(form: GetPosts) {
-    return this.wrapper<GetPosts, GetPostsResponse>(
+    return await this.wrapper<GetPosts, GetPostsResponse>(
       HttpType.Get,
       "/post/list",
       form
@@ -488,7 +527,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/like`
    */
   async likePost(form: CreatePostLike) {
-    return this.wrapper<CreatePostLike, PostResponse>(
+    return await this.wrapper<CreatePostLike, PostResponse>(
       HttpType.Post,
       "/post/like",
       form
@@ -501,7 +540,7 @@ export class LemmyHttp {
    * `HTTP.PUT /post/save`
    */
   async savePost(form: SavePost) {
-    return this.wrapper<SavePost, PostResponse>(
+    return await this.wrapper<SavePost, PostResponse>(
       HttpType.Put,
       "/post/save",
       form
@@ -514,7 +553,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/report`
    */
   async createPostReport(form: CreatePostReport) {
-    return this.wrapper<CreatePostReport, PostReportResponse>(
+    return await this.wrapper<CreatePostReport, PostReportResponse>(
       HttpType.Post,
       "/post/report",
       form
@@ -527,7 +566,7 @@ export class LemmyHttp {
    * `HTTP.PUT /post/report/resolve`
    */
   async resolvePostReport(form: ResolvePostReport) {
-    return this.wrapper<ResolvePostReport, PostReportResponse>(
+    return await this.wrapper<ResolvePostReport, PostReportResponse>(
       HttpType.Put,
       "/post/report/resolve",
       form
@@ -540,7 +579,7 @@ export class LemmyHttp {
    * `HTTP.GET /post/report/list`
    */
   async listPostReports(form: ListPostReports) {
-    return this.wrapper<ListPostReports, ListPostReportsResponse>(
+    return await this.wrapper<ListPostReports, ListPostReportsResponse>(
       HttpType.Get,
       "/post/report/list",
       form
@@ -553,7 +592,7 @@ export class LemmyHttp {
    * `HTTP.GET /post/site_metadata`
    */
   async getSiteMetadata(form: GetSiteMetadata) {
-    return this.wrapper<GetSiteMetadata, GetSiteMetadataResponse>(
+    return await this.wrapper<GetSiteMetadata, GetSiteMetadataResponse>(
       HttpType.Get,
       "/post/site_metadata",
       form
@@ -566,7 +605,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment`
    */
   async createComment(form: CreateComment) {
-    return this.wrapper<CreateComment, CommentResponse>(
+    return await this.wrapper<CreateComment, CommentResponse>(
       HttpType.Post,
       "/comment",
       form
@@ -579,7 +618,7 @@ export class LemmyHttp {
    * `HTTP.PUT /comment`
    */
   async editComment(form: EditComment) {
-    return this.wrapper<EditComment, CommentResponse>(
+    return await this.wrapper<EditComment, CommentResponse>(
       HttpType.Put,
       "/comment",
       form
@@ -592,7 +631,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/delete`
    */
   async deleteComment(form: DeleteComment) {
-    return this.wrapper<DeleteComment, CommentResponse>(
+    return await this.wrapper<DeleteComment, CommentResponse>(
       HttpType.Post,
       "/comment/delete",
       form
@@ -605,7 +644,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/remove`
    */
   async removeComment(form: RemoveComment) {
-    return this.wrapper<RemoveComment, CommentResponse>(
+    return await this.wrapper<RemoveComment, CommentResponse>(
       HttpType.Post,
       "/comment/remove",
       form
@@ -618,7 +657,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/mark_as_read`
    */
   async markCommentReplyAsRead(form: MarkCommentReplyAsRead) {
-    return this.wrapper<MarkCommentReplyAsRead, CommentResponse>(
+    return await this.wrapper<MarkCommentReplyAsRead, CommentResponse>(
       HttpType.Post,
       "/comment/mark_as_read",
       form
@@ -631,7 +670,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/like`
    */
   async likeComment(form: CreateCommentLike) {
-    return this.wrapper<CreateCommentLike, CommentResponse>(
+    return await this.wrapper<CreateCommentLike, CommentResponse>(
       HttpType.Post,
       "/comment/like",
       form
@@ -644,7 +683,7 @@ export class LemmyHttp {
    * `HTTP.PUT /comment/save`
    */
   async saveComment(form: SaveComment) {
-    return this.wrapper<SaveComment, CommentResponse>(
+    return await this.wrapper<SaveComment, CommentResponse>(
       HttpType.Put,
       "/comment/save",
       form
@@ -657,7 +696,7 @@ export class LemmyHttp {
    * `HTTP.GET /comment/list`
    */
   async getComments(form: GetComments) {
-    return this.wrapper<GetComments, GetCommentsResponse>(
+    return await this.wrapper<GetComments, GetCommentsResponse>(
       HttpType.Get,
       "/comment/list",
       form
@@ -670,7 +709,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/report`
    */
   async createCommentReport(form: CreateCommentReport) {
-    return this.wrapper<CreateCommentReport, CommentReportResponse>(
+    return await this.wrapper<CreateCommentReport, CommentReportResponse>(
       HttpType.Post,
       "/comment/report",
       form
@@ -683,7 +722,7 @@ export class LemmyHttp {
    * `HTTP.PUT /comment/report/resolve`
    */
   async resolveCommentReport(form: ResolveCommentReport) {
-    return this.wrapper<ResolveCommentReport, CommentReportResponse>(
+    return await this.wrapper<ResolveCommentReport, CommentReportResponse>(
       HttpType.Put,
       "/comment/report/resolve",
       form
@@ -696,7 +735,7 @@ export class LemmyHttp {
    * `HTTP.GET /comment/report/list`
    */
   async listCommentReports(form: ListCommentReports) {
-    return this.wrapper<ListCommentReports, ListCommentReportsResponse>(
+    return await this.wrapper<ListCommentReports, ListCommentReportsResponse>(
       HttpType.Get,
       "/comment/report/list",
       form
@@ -709,7 +748,7 @@ export class LemmyHttp {
    * `HTTP.GET /private_message/list`
    */
   async getPrivateMessages(form: GetPrivateMessages) {
-    return this.wrapper<GetPrivateMessages, PrivateMessagesResponse>(
+    return await this.wrapper<GetPrivateMessages, PrivateMessagesResponse>(
       HttpType.Get,
       "/private_message/list",
       form
@@ -722,7 +761,7 @@ export class LemmyHttp {
    * `HTTP.POST /private_message`
    */
   async createPrivateMessage(form: CreatePrivateMessage) {
-    return this.wrapper<CreatePrivateMessage, PrivateMessageResponse>(
+    return await this.wrapper<CreatePrivateMessage, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message",
       form
@@ -735,7 +774,7 @@ export class LemmyHttp {
    * `HTTP.PUT /private_message`
    */
   async editPrivateMessage(form: EditPrivateMessage) {
-    return this.wrapper<EditPrivateMessage, PrivateMessageResponse>(
+    return await this.wrapper<EditPrivateMessage, PrivateMessageResponse>(
       HttpType.Put,
       "/private_message",
       form
@@ -748,7 +787,7 @@ export class LemmyHttp {
    * `HTTP.POST /private_message/delete`
    */
   async deletePrivateMessage(form: DeletePrivateMessage) {
-    return this.wrapper<DeletePrivateMessage, PrivateMessageResponse>(
+    return await this.wrapper<DeletePrivateMessage, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message/delete",
       form
@@ -761,7 +800,7 @@ export class LemmyHttp {
    * `HTTP.POST /private_message/mark_as_read`
    */
   async markPrivateMessageAsRead(form: MarkPrivateMessageAsRead) {
-    return this.wrapper<MarkPrivateMessageAsRead, PrivateMessageResponse>(
+    return await this.wrapper<MarkPrivateMessageAsRead, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message/mark_as_read",
       form
@@ -774,7 +813,7 @@ export class LemmyHttp {
    * `HTTP.POST /private_message/report`
    */
   async createPrivateMessageReport(form: CreatePrivateMessageReport) {
-    return this.wrapper<
+    return await this.wrapper<
       CreatePrivateMessageReport,
       PrivateMessageReportResponse
     >(HttpType.Post, "/private_message/report", form);
@@ -786,7 +825,7 @@ export class LemmyHttp {
    * `HTTP.PUT /private_message/report/resolve`
    */
   async resolvePrivateMessageReport(form: ResolvePrivateMessageReport) {
-    return this.wrapper<
+    return await this.wrapper<
       ResolvePrivateMessageReport,
       PrivateMessageReportResponse
     >(HttpType.Put, "/private_message/report/resolve", form);
@@ -798,7 +837,7 @@ export class LemmyHttp {
    * `HTTP.GET /private_message/report/list`
    */
   async listPrivateMessageReports(form: ListPrivateMessageReports) {
-    return this.wrapper<
+    return await this.wrapper<
       ListPrivateMessageReports,
       ListPrivateMessageReportsResponse
     >(HttpType.Get, "/private_message/report/list", form);
@@ -810,7 +849,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/register`
    */
   async register(form: Register) {
-    return this.wrapper<Register, LoginResponse>(
+    return await this.wrapper<Register, LoginResponse>(
       HttpType.Post,
       "/user/register",
       form
@@ -823,7 +862,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/login`
    */
   async login(form: Login) {
-    return this.wrapper<Login, LoginResponse>(
+    return await this.wrapper<Login, LoginResponse>(
       HttpType.Post,
       "/user/login",
       form
@@ -836,7 +875,7 @@ export class LemmyHttp {
    * `HTTP.GET /user`
    */
   async getPersonDetails(form: GetPersonDetails) {
-    return this.wrapper<GetPersonDetails, GetPersonDetailsResponse>(
+    return await this.wrapper<GetPersonDetails, GetPersonDetailsResponse>(
       HttpType.Get,
       "/user",
       form
@@ -849,7 +888,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/mention`
    */
   async getPersonMentions(form: GetPersonMentions) {
-    return this.wrapper<GetPersonMentions, GetPersonMentionsResponse>(
+    return await this.wrapper<GetPersonMentions, GetPersonMentionsResponse>(
       HttpType.Get,
       "/user/mention",
       form
@@ -862,7 +901,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/mention/mark_as_read`
    */
   async markPersonMentionAsRead(form: MarkPersonMentionAsRead) {
-    return this.wrapper<MarkPersonMentionAsRead, PersonMentionResponse>(
+    return await this.wrapper<MarkPersonMentionAsRead, PersonMentionResponse>(
       HttpType.Post,
       "/user/mention/mark_as_read",
       form
@@ -875,7 +914,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/replies`
    */
   async getReplies(form: GetReplies) {
-    return this.wrapper<GetReplies, GetRepliesResponse>(
+    return await this.wrapper<GetReplies, GetRepliesResponse>(
       HttpType.Get,
       "/user/replies",
       form
@@ -888,7 +927,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/ban`
    */
   async banPerson(form: BanPerson) {
-    return this.wrapper<BanPerson, BanPersonResponse>(
+    return await this.wrapper<BanPerson, BanPersonResponse>(
       HttpType.Post,
       "/user/ban",
       form
@@ -901,7 +940,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/banned`
    */
   async getBannedPersons(form: GetBannedPersons) {
-    return this.wrapper<GetBannedPersons, BannedPersonsResponse>(
+    return await this.wrapper<GetBannedPersons, BannedPersonsResponse>(
       HttpType.Get,
       "/user/banned",
       form
@@ -914,7 +953,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/block`
    */
   async blockPerson(form: BlockPerson) {
-    return this.wrapper<BlockPerson, BlockPersonResponse>(
+    return await this.wrapper<BlockPerson, BlockPersonResponse>(
       HttpType.Post,
       "/user/block",
       form
@@ -927,7 +966,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/get_captcha`
    */
   async getCaptcha() {
-    return this.wrapper<any, GetCaptchaResponse>(
+    return await this.wrapper<any, GetCaptchaResponse>(
       HttpType.Get,
       "/user/get_captcha",
       {}
@@ -940,7 +979,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/delete_account`
    */
   async deleteAccount(form: DeleteAccount) {
-    return this.wrapper<DeleteAccount, DeleteAccountResponse>(
+    return await this.wrapper<DeleteAccount, DeleteAccountResponse>(
       HttpType.Post,
       "/user/delete_account",
       form
@@ -953,7 +992,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/password_reset`
    */
   async passwordReset(form: PasswordReset) {
-    return this.wrapper<PasswordReset, PasswordResetResponse>(
+    return await this.wrapper<PasswordReset, PasswordResetResponse>(
       HttpType.Post,
       "/user/password_reset",
       form
@@ -966,7 +1005,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/password_change`
    */
   async passwordChange(form: PasswordChange) {
-    return this.wrapper<PasswordChange, LoginResponse>(
+    return await this.wrapper<PasswordChange, LoginResponse>(
       HttpType.Post,
       "/user/password_change",
       form
@@ -979,7 +1018,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/mark_all_as_read`
    */
   async markAllAsRead(form: MarkAllAsRead) {
-    return this.wrapper<MarkAllAsRead, GetRepliesResponse>(
+    return await this.wrapper<MarkAllAsRead, GetRepliesResponse>(
       HttpType.Post,
       "/user/mark_all_as_read",
       form
@@ -992,7 +1031,7 @@ export class LemmyHttp {
    * `HTTP.PUT /user/save_user_settings`
    */
   async saveUserSettings(form: SaveUserSettings) {
-    return this.wrapper<SaveUserSettings, LoginResponse>(
+    return await this.wrapper<SaveUserSettings, LoginResponse>(
       HttpType.Put,
       "/user/save_user_settings",
       form
@@ -1005,7 +1044,7 @@ export class LemmyHttp {
    * `HTTP.PUT /user/change_password`
    */
   async changePassword(form: ChangePassword) {
-    return this.wrapper<ChangePassword, LoginResponse>(
+    return await this.wrapper<ChangePassword, LoginResponse>(
       HttpType.Put,
       "/user/change_password",
       form
@@ -1018,7 +1057,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/report_count`
    */
   async getReportCount(form: GetReportCount) {
-    return this.wrapper<GetReportCount, GetReportCountResponse>(
+    return await this.wrapper<GetReportCount, GetReportCountResponse>(
       HttpType.Get,
       "/user/report_count",
       form
@@ -1031,7 +1070,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/unread_count`
    */
   async getUnreadCount(form: GetUnreadCount) {
-    return this.wrapper<GetUnreadCount, GetUnreadCountResponse>(
+    return await this.wrapper<GetUnreadCount, GetUnreadCountResponse>(
       HttpType.Get,
       "/user/unread_count",
       form
@@ -1044,7 +1083,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/verify_email`
    */
   async verifyEmail(form: VerifyEmail) {
-    return this.wrapper<VerifyEmail, VerifyEmailResponse>(
+    return await this.wrapper<VerifyEmail, VerifyEmailResponse>(
       HttpType.Post,
       "/user/verify_email",
       form
@@ -1057,7 +1096,7 @@ export class LemmyHttp {
    * `HTTP.POST /admin/add`
    */
   async addAdmin(form: AddAdmin) {
-    return this.wrapper<AddAdmin, AddAdminResponse>(
+    return await this.wrapper<AddAdmin, AddAdminResponse>(
       HttpType.Post,
       "/admin/add",
       form
@@ -1072,7 +1111,7 @@ export class LemmyHttp {
   async getUnreadRegistrationApplicationCount(
     form: GetUnreadRegistrationApplicationCount
   ) {
-    return this.wrapper<
+    return await this.wrapper<
       GetUnreadRegistrationApplicationCount,
       GetUnreadRegistrationApplicationCountResponse
     >(HttpType.Get, "/admin/registration_application/count", form);
@@ -1084,7 +1123,7 @@ export class LemmyHttp {
    * `HTTP.GET /admin/registration_application/list`
    */
   async listRegistrationApplications(form: ListRegistrationApplications) {
-    return this.wrapper<
+    return await this.wrapper<
       ListRegistrationApplications,
       ListRegistrationApplicationsResponse
     >(HttpType.Get, "/admin/registration_application/list", form);
@@ -1096,7 +1135,7 @@ export class LemmyHttp {
    * `HTTP.PUT /admin/registration_application/approve`
    */
   async approveRegistrationApplication(form: ApproveRegistrationApplication) {
-    return this.wrapper<
+    return await this.wrapper<
       ApproveRegistrationApplication,
       RegistrationApplicationResponse
     >(HttpType.Put, "/admin/registration_application/approve", form);
@@ -1108,7 +1147,7 @@ export class LemmyHttp {
    * `HTTP.POST /admin/purge/person`
    */
   async purgePerson(form: PurgePerson) {
-    return this.wrapper<PurgePerson, PurgeItemResponse>(
+    return await this.wrapper<PurgePerson, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/person",
       form
@@ -1121,7 +1160,7 @@ export class LemmyHttp {
    * `HTTP.POST /admin/purge/community`
    */
   async purgeCommunity(form: PurgeCommunity) {
-    return this.wrapper<PurgeCommunity, PurgeItemResponse>(
+    return await this.wrapper<PurgeCommunity, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/community",
       form
@@ -1134,7 +1173,7 @@ export class LemmyHttp {
    * `HTTP.POST /admin/purge/post`
    */
   async purgePost(form: PurgePost) {
-    return this.wrapper<PurgePost, PurgeItemResponse>(
+    return await this.wrapper<PurgePost, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/post",
       form
@@ -1147,14 +1186,52 @@ export class LemmyHttp {
    * `HTTP.POST /admin/purge/comment`
    */
   async purgeComment(form: PurgeComment) {
-    return this.wrapper<PurgeComment, PurgeItemResponse>(
+    return await this.wrapper<PurgeComment, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/comment",
       form
     );
   }
 
-  private buildFullUrl(endpoint: string): string {
+  async uploadImage({
+    image,
+    auth,
+  }: UploadImage): Promise<UploadImageResponse> {
+    const formData = await createFormData(image);
+
+    // If jwt cookie not already set by browser, set it with passed in auth
+    let headers: Record<string, string> | undefined = undefined;
+    if (!globalThis?.document?.cookie?.includes("jwt=")) {
+      headers = {
+        Cookie: `jwt=${auth}`,
+      };
+    }
+
+    let url: string | undefined = undefined;
+    let delete_url: string | undefined = undefined;
+
+    const response = await fetch(this.pictrsUrl, {
+      method: HttpType.Post,
+      body: formData,
+      headers,
+    });
+
+    const responseJson = await response.json();
+
+    if (responseJson.msg == "ok") {
+      const { file: hash, delete_token: deleteToken } = responseJson.files[0];
+      delete_url = `${this.pictrsUrl}/delete/${deleteToken}/${hash}`;
+      url = `${this.pictrsUrl}/${hash}`;
+    }
+
+    return {
+      ...responseJson,
+      url,
+      delete_url,
+    };
+  }
+
+  private buildFullUrl(endpoint: string) {
     return `${this.apiUrl}${endpoint}`;
   }
 
@@ -1164,20 +1241,24 @@ export class LemmyHttp {
     form: BodyType
   ): Promise<ResponseType> {
     if (type_ == HttpType.Get) {
-      let getUrl = `${this.buildFullUrl(endpoint)}?${encodeGetParams(form)}`;
-      return fetch(getUrl, {
-        method: "GET",
+      const getUrl = `${this.buildFullUrl(endpoint)}?${encodeGetParams(form)}`;
+      const response = await fetch(getUrl, {
+        method: HttpType.Get,
         headers: this.headers,
-      }).then(d => d.json() as Promise<ResponseType>);
+      });
+
+      return await response.json();
     } else {
-      return fetch(this.buildFullUrl(endpoint), {
+      const response = await fetch(this.buildFullUrl(endpoint), {
         method: type_,
         headers: {
           "Content-Type": "application/json",
           ...this.headers,
         },
         body: JSON.stringify(form),
-      }).then(d => d.json() as Promise<ResponseType>);
+      });
+
+      return await response.json();
     }
   }
 }
@@ -1187,4 +1268,40 @@ function encodeGetParams<BodyType extends object>(p: BodyType): string {
     .filter(kv => !!kv[1])
     .map(kv => kv.map(encodeURIComponent).join("="))
     .join("&");
+}
+
+async function createFormData(image: Blob | Buffer) {
+  const file = await createFile(image);
+  let formData: FormData;
+
+  if (globalThis?.FormData) {
+    formData = new FormData();
+  } else {
+    const FormData = (await dynamicImport("node-fetch")).FormData;
+    formData = new FormData();
+  }
+
+  formData.append("images[]", file);
+
+  return formData;
+}
+
+// The File constructor needs a filename to make a new file, but it doesn't actually
+// effect the name or for a name and is smart enough to figure out the filetype without
+// looking at the file extension.
+const imageFileName = "image.jpg";
+
+async function createFile(image: Blob | Buffer) {
+  let file = image;
+
+  if (file.constructor.name !== "File") {
+    if (globalThis?.File) {
+      file = new File([image], imageFileName);
+    } else {
+      const File = (await dynamicImport("node-fetch")).File;
+      file = new File([image], imageFileName);
+    }
+  }
+
+  return file as File;
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -176,11 +176,7 @@ export class LemmyHttp {
    * `HTTP.GET /site`
    */
   async getSite(form: GetSite) {
-    return await this.wrapper<GetSite, GetSiteResponse>(
-      HttpType.Get,
-      "/site",
-      form
-    );
+    return this.wrapper<GetSite, GetSiteResponse>(HttpType.Get, "/site", form);
   }
 
   /**
@@ -189,11 +185,7 @@ export class LemmyHttp {
    * `HTTP.POST /site`
    */
   async createSite(form: CreateSite) {
-    return await this.wrapper<CreateSite, SiteResponse>(
-      HttpType.Post,
-      "/site",
-      form
-    );
+    return this.wrapper<CreateSite, SiteResponse>(HttpType.Post, "/site", form);
   }
 
   /**
@@ -202,11 +194,7 @@ export class LemmyHttp {
    * `HTTP.PUT /site`
    */
   async editSite(form: EditSite) {
-    return await this.wrapper<EditSite, SiteResponse>(
-      HttpType.Put,
-      "/site",
-      form
-    );
+    return this.wrapper<EditSite, SiteResponse>(HttpType.Put, "/site", form);
   }
 
   /**
@@ -215,7 +203,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/leave_admin`
    */
   async leaveAdmin(form: LeaveAdmin) {
-    return await this.wrapper<LeaveAdmin, GetSiteResponse>(
+    return this.wrapper<LeaveAdmin, GetSiteResponse>(
       HttpType.Post,
       "/user/leave_admin",
       form
@@ -228,7 +216,7 @@ export class LemmyHttp {
    * `HTTP.GET /modlog`
    */
   async getModlog(form: GetModlog) {
-    return await this.wrapper<GetModlog, GetModlogResponse>(
+    return this.wrapper<GetModlog, GetModlogResponse>(
       HttpType.Get,
       "/modlog",
       form
@@ -241,11 +229,7 @@ export class LemmyHttp {
    * `HTTP.GET /search`
    */
   async search(form: Search) {
-    return await this.wrapper<Search, SearchResponse>(
-      HttpType.Get,
-      "/search",
-      form
-    );
+    return this.wrapper<Search, SearchResponse>(HttpType.Get, "/search", form);
   }
 
   /**
@@ -254,7 +238,7 @@ export class LemmyHttp {
    * `HTTP.GET /resolve_object`
    */
   async resolveObject(form: ResolveObject) {
-    return await this.wrapper<ResolveObject, ResolveObjectResponse>(
+    return this.wrapper<ResolveObject, ResolveObjectResponse>(
       HttpType.Get,
       "/resolve_object",
       form
@@ -267,7 +251,7 @@ export class LemmyHttp {
    * `HTTP.POST /community`
    */
   async createCommunity(form: CreateCommunity) {
-    return await this.wrapper<CreateCommunity, CommunityResponse>(
+    return this.wrapper<CreateCommunity, CommunityResponse>(
       HttpType.Post,
       "/community",
       form
@@ -280,7 +264,7 @@ export class LemmyHttp {
    * `HTTP.GET /community`
    */
   async getCommunity(form: GetCommunity) {
-    return await this.wrapper<GetCommunity, GetCommunityResponse>(
+    return this.wrapper<GetCommunity, GetCommunityResponse>(
       HttpType.Get,
       "/community",
       form
@@ -293,7 +277,7 @@ export class LemmyHttp {
    * `HTTP.PUT /community`
    */
   async editCommunity(form: EditCommunity) {
-    return await this.wrapper<EditCommunity, CommunityResponse>(
+    return this.wrapper<EditCommunity, CommunityResponse>(
       HttpType.Put,
       "/community",
       form
@@ -306,7 +290,7 @@ export class LemmyHttp {
    * `HTTP.GET /community/list`
    */
   async listCommunities(form: ListCommunities) {
-    return await this.wrapper<ListCommunities, ListCommunitiesResponse>(
+    return this.wrapper<ListCommunities, ListCommunitiesResponse>(
       HttpType.Get,
       "/community/list",
       form
@@ -319,7 +303,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/follow`
    */
   async followCommunity(form: FollowCommunity) {
-    return await this.wrapper<FollowCommunity, CommunityResponse>(
+    return this.wrapper<FollowCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/follow",
       form
@@ -332,7 +316,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/block`
    */
   async blockCommunity(form: BlockCommunity) {
-    return await this.wrapper<BlockCommunity, BlockCommunityResponse>(
+    return this.wrapper<BlockCommunity, BlockCommunityResponse>(
       HttpType.Post,
       "/community/block",
       form
@@ -345,7 +329,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/delete`
    */
   async deleteCommunity(form: DeleteCommunity) {
-    return await this.wrapper<DeleteCommunity, CommunityResponse>(
+    return this.wrapper<DeleteCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/delete",
       form
@@ -358,7 +342,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/remove`
    */
   async removeCommunity(form: RemoveCommunity) {
-    return await this.wrapper<RemoveCommunity, CommunityResponse>(
+    return this.wrapper<RemoveCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/remove",
       form
@@ -371,7 +355,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/transfer`
    */
   async transferCommunity(form: TransferCommunity) {
-    return await this.wrapper<TransferCommunity, GetCommunityResponse>(
+    return this.wrapper<TransferCommunity, GetCommunityResponse>(
       HttpType.Post,
       "/community/transfer",
       form
@@ -384,7 +368,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/ban_user`
    */
   async banFromCommunity(form: BanFromCommunity) {
-    return await this.wrapper<BanFromCommunity, BanFromCommunityResponse>(
+    return this.wrapper<BanFromCommunity, BanFromCommunityResponse>(
       HttpType.Post,
       "/community/ban_user",
       form
@@ -397,7 +381,7 @@ export class LemmyHttp {
    * `HTTP.POST /community/mod`
    */
   async addModToCommunity(form: AddModToCommunity) {
-    return await this.wrapper<AddModToCommunity, AddModToCommunityResponse>(
+    return this.wrapper<AddModToCommunity, AddModToCommunityResponse>(
       HttpType.Post,
       "/community/mod",
       form
@@ -410,11 +394,7 @@ export class LemmyHttp {
    * `HTTP.POST /post`
    */
   async createPost(form: CreatePost) {
-    return await this.wrapper<CreatePost, PostResponse>(
-      HttpType.Post,
-      "/post",
-      form
-    );
+    return this.wrapper<CreatePost, PostResponse>(HttpType.Post, "/post", form);
   }
 
   /**
@@ -423,11 +403,7 @@ export class LemmyHttp {
    * `HTTP.GET /post`
    */
   async getPost(form: GetPost) {
-    return await this.wrapper<GetPost, GetPostResponse>(
-      HttpType.Get,
-      "/post",
-      form
-    );
+    return this.wrapper<GetPost, GetPostResponse>(HttpType.Get, "/post", form);
   }
 
   /**
@@ -436,11 +412,7 @@ export class LemmyHttp {
    * `HTTP.PUT /post`
    */
   async editPost(form: EditPost) {
-    return await this.wrapper<EditPost, PostResponse>(
-      HttpType.Put,
-      "/post",
-      form
-    );
+    return this.wrapper<EditPost, PostResponse>(HttpType.Put, "/post", form);
   }
 
   /**
@@ -449,7 +421,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/delete`
    */
   async deletePost(form: DeletePost) {
-    return await this.wrapper<DeletePost, PostResponse>(
+    return this.wrapper<DeletePost, PostResponse>(
       HttpType.Post,
       "/post/delete",
       form
@@ -462,7 +434,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/remove`
    */
   async removePost(form: RemovePost) {
-    return await this.wrapper<RemovePost, PostResponse>(
+    return this.wrapper<RemovePost, PostResponse>(
       HttpType.Post,
       "/post/remove",
       form
@@ -475,7 +447,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/mark_as_read`
    */
   async markPostAsRead(form: MarkPostAsRead) {
-    return await this.wrapper<MarkPostAsRead, PostResponse>(
+    return this.wrapper<MarkPostAsRead, PostResponse>(
       HttpType.Post,
       "/post/mark_as_read",
       form
@@ -488,7 +460,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/lock`
    */
   async lockPost(form: LockPost) {
-    return await this.wrapper<LockPost, PostResponse>(
+    return this.wrapper<LockPost, PostResponse>(
       HttpType.Post,
       "/post/lock",
       form
@@ -501,7 +473,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/feature`
    */
   async featurePost(form: FeaturePost) {
-    return await this.wrapper<FeaturePost, PostResponse>(
+    return this.wrapper<FeaturePost, PostResponse>(
       HttpType.Post,
       "/post/feature",
       form
@@ -514,7 +486,7 @@ export class LemmyHttp {
    * `HTTP.GET /post/list`
    */
   async getPosts(form: GetPosts) {
-    return await this.wrapper<GetPosts, GetPostsResponse>(
+    return this.wrapper<GetPosts, GetPostsResponse>(
       HttpType.Get,
       "/post/list",
       form
@@ -527,7 +499,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/like`
    */
   async likePost(form: CreatePostLike) {
-    return await this.wrapper<CreatePostLike, PostResponse>(
+    return this.wrapper<CreatePostLike, PostResponse>(
       HttpType.Post,
       "/post/like",
       form
@@ -540,7 +512,7 @@ export class LemmyHttp {
    * `HTTP.PUT /post/save`
    */
   async savePost(form: SavePost) {
-    return await this.wrapper<SavePost, PostResponse>(
+    return this.wrapper<SavePost, PostResponse>(
       HttpType.Put,
       "/post/save",
       form
@@ -553,7 +525,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/report`
    */
   async createPostReport(form: CreatePostReport) {
-    return await this.wrapper<CreatePostReport, PostReportResponse>(
+    return this.wrapper<CreatePostReport, PostReportResponse>(
       HttpType.Post,
       "/post/report",
       form
@@ -566,7 +538,7 @@ export class LemmyHttp {
    * `HTTP.PUT /post/report/resolve`
    */
   async resolvePostReport(form: ResolvePostReport) {
-    return await this.wrapper<ResolvePostReport, PostReportResponse>(
+    return this.wrapper<ResolvePostReport, PostReportResponse>(
       HttpType.Put,
       "/post/report/resolve",
       form
@@ -579,7 +551,7 @@ export class LemmyHttp {
    * `HTTP.GET /post/report/list`
    */
   async listPostReports(form: ListPostReports) {
-    return await this.wrapper<ListPostReports, ListPostReportsResponse>(
+    return this.wrapper<ListPostReports, ListPostReportsResponse>(
       HttpType.Get,
       "/post/report/list",
       form
@@ -592,7 +564,7 @@ export class LemmyHttp {
    * `HTTP.GET /post/site_metadata`
    */
   async getSiteMetadata(form: GetSiteMetadata) {
-    return await this.wrapper<GetSiteMetadata, GetSiteMetadataResponse>(
+    return this.wrapper<GetSiteMetadata, GetSiteMetadataResponse>(
       HttpType.Get,
       "/post/site_metadata",
       form
@@ -605,7 +577,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment`
    */
   async createComment(form: CreateComment) {
-    return await this.wrapper<CreateComment, CommentResponse>(
+    return this.wrapper<CreateComment, CommentResponse>(
       HttpType.Post,
       "/comment",
       form
@@ -618,7 +590,7 @@ export class LemmyHttp {
    * `HTTP.PUT /comment`
    */
   async editComment(form: EditComment) {
-    return await this.wrapper<EditComment, CommentResponse>(
+    return this.wrapper<EditComment, CommentResponse>(
       HttpType.Put,
       "/comment",
       form
@@ -631,7 +603,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/delete`
    */
   async deleteComment(form: DeleteComment) {
-    return await this.wrapper<DeleteComment, CommentResponse>(
+    return this.wrapper<DeleteComment, CommentResponse>(
       HttpType.Post,
       "/comment/delete",
       form
@@ -644,7 +616,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/remove`
    */
   async removeComment(form: RemoveComment) {
-    return await this.wrapper<RemoveComment, CommentResponse>(
+    return this.wrapper<RemoveComment, CommentResponse>(
       HttpType.Post,
       "/comment/remove",
       form
@@ -657,7 +629,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/mark_as_read`
    */
   async markCommentReplyAsRead(form: MarkCommentReplyAsRead) {
-    return await this.wrapper<MarkCommentReplyAsRead, CommentResponse>(
+    return this.wrapper<MarkCommentReplyAsRead, CommentResponse>(
       HttpType.Post,
       "/comment/mark_as_read",
       form
@@ -670,7 +642,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/like`
    */
   async likeComment(form: CreateCommentLike) {
-    return await this.wrapper<CreateCommentLike, CommentResponse>(
+    return this.wrapper<CreateCommentLike, CommentResponse>(
       HttpType.Post,
       "/comment/like",
       form
@@ -683,7 +655,7 @@ export class LemmyHttp {
    * `HTTP.PUT /comment/save`
    */
   async saveComment(form: SaveComment) {
-    return await this.wrapper<SaveComment, CommentResponse>(
+    return this.wrapper<SaveComment, CommentResponse>(
       HttpType.Put,
       "/comment/save",
       form
@@ -696,7 +668,7 @@ export class LemmyHttp {
    * `HTTP.GET /comment/list`
    */
   async getComments(form: GetComments) {
-    return await this.wrapper<GetComments, GetCommentsResponse>(
+    return this.wrapper<GetComments, GetCommentsResponse>(
       HttpType.Get,
       "/comment/list",
       form
@@ -709,7 +681,7 @@ export class LemmyHttp {
    * `HTTP.POST /comment/report`
    */
   async createCommentReport(form: CreateCommentReport) {
-    return await this.wrapper<CreateCommentReport, CommentReportResponse>(
+    return this.wrapper<CreateCommentReport, CommentReportResponse>(
       HttpType.Post,
       "/comment/report",
       form
@@ -722,7 +694,7 @@ export class LemmyHttp {
    * `HTTP.PUT /comment/report/resolve`
    */
   async resolveCommentReport(form: ResolveCommentReport) {
-    return await this.wrapper<ResolveCommentReport, CommentReportResponse>(
+    return this.wrapper<ResolveCommentReport, CommentReportResponse>(
       HttpType.Put,
       "/comment/report/resolve",
       form
@@ -735,7 +707,7 @@ export class LemmyHttp {
    * `HTTP.GET /comment/report/list`
    */
   async listCommentReports(form: ListCommentReports) {
-    return await this.wrapper<ListCommentReports, ListCommentReportsResponse>(
+    return this.wrapper<ListCommentReports, ListCommentReportsResponse>(
       HttpType.Get,
       "/comment/report/list",
       form
@@ -748,7 +720,7 @@ export class LemmyHttp {
    * `HTTP.GET /private_message/list`
    */
   async getPrivateMessages(form: GetPrivateMessages) {
-    return await this.wrapper<GetPrivateMessages, PrivateMessagesResponse>(
+    return this.wrapper<GetPrivateMessages, PrivateMessagesResponse>(
       HttpType.Get,
       "/private_message/list",
       form
@@ -761,7 +733,7 @@ export class LemmyHttp {
    * `HTTP.POST /private_message`
    */
   async createPrivateMessage(form: CreatePrivateMessage) {
-    return await this.wrapper<CreatePrivateMessage, PrivateMessageResponse>(
+    return this.wrapper<CreatePrivateMessage, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message",
       form
@@ -774,7 +746,7 @@ export class LemmyHttp {
    * `HTTP.PUT /private_message`
    */
   async editPrivateMessage(form: EditPrivateMessage) {
-    return await this.wrapper<EditPrivateMessage, PrivateMessageResponse>(
+    return this.wrapper<EditPrivateMessage, PrivateMessageResponse>(
       HttpType.Put,
       "/private_message",
       form
@@ -787,7 +759,7 @@ export class LemmyHttp {
    * `HTTP.POST /private_message/delete`
    */
   async deletePrivateMessage(form: DeletePrivateMessage) {
-    return await this.wrapper<DeletePrivateMessage, PrivateMessageResponse>(
+    return this.wrapper<DeletePrivateMessage, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message/delete",
       form
@@ -800,7 +772,7 @@ export class LemmyHttp {
    * `HTTP.POST /private_message/mark_as_read`
    */
   async markPrivateMessageAsRead(form: MarkPrivateMessageAsRead) {
-    return await this.wrapper<MarkPrivateMessageAsRead, PrivateMessageResponse>(
+    return this.wrapper<MarkPrivateMessageAsRead, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message/mark_as_read",
       form
@@ -813,7 +785,7 @@ export class LemmyHttp {
    * `HTTP.POST /private_message/report`
    */
   async createPrivateMessageReport(form: CreatePrivateMessageReport) {
-    return await this.wrapper<
+    return this.wrapper<
       CreatePrivateMessageReport,
       PrivateMessageReportResponse
     >(HttpType.Post, "/private_message/report", form);
@@ -825,7 +797,7 @@ export class LemmyHttp {
    * `HTTP.PUT /private_message/report/resolve`
    */
   async resolvePrivateMessageReport(form: ResolvePrivateMessageReport) {
-    return await this.wrapper<
+    return this.wrapper<
       ResolvePrivateMessageReport,
       PrivateMessageReportResponse
     >(HttpType.Put, "/private_message/report/resolve", form);
@@ -837,7 +809,7 @@ export class LemmyHttp {
    * `HTTP.GET /private_message/report/list`
    */
   async listPrivateMessageReports(form: ListPrivateMessageReports) {
-    return await this.wrapper<
+    return this.wrapper<
       ListPrivateMessageReports,
       ListPrivateMessageReportsResponse
     >(HttpType.Get, "/private_message/report/list", form);
@@ -849,7 +821,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/register`
    */
   async register(form: Register) {
-    return await this.wrapper<Register, LoginResponse>(
+    return this.wrapper<Register, LoginResponse>(
       HttpType.Post,
       "/user/register",
       form
@@ -862,7 +834,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/login`
    */
   async login(form: Login) {
-    return await this.wrapper<Login, LoginResponse>(
+    return this.wrapper<Login, LoginResponse>(
       HttpType.Post,
       "/user/login",
       form
@@ -875,7 +847,7 @@ export class LemmyHttp {
    * `HTTP.GET /user`
    */
   async getPersonDetails(form: GetPersonDetails) {
-    return await this.wrapper<GetPersonDetails, GetPersonDetailsResponse>(
+    return this.wrapper<GetPersonDetails, GetPersonDetailsResponse>(
       HttpType.Get,
       "/user",
       form
@@ -888,7 +860,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/mention`
    */
   async getPersonMentions(form: GetPersonMentions) {
-    return await this.wrapper<GetPersonMentions, GetPersonMentionsResponse>(
+    return this.wrapper<GetPersonMentions, GetPersonMentionsResponse>(
       HttpType.Get,
       "/user/mention",
       form
@@ -901,7 +873,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/mention/mark_as_read`
    */
   async markPersonMentionAsRead(form: MarkPersonMentionAsRead) {
-    return await this.wrapper<MarkPersonMentionAsRead, PersonMentionResponse>(
+    return this.wrapper<MarkPersonMentionAsRead, PersonMentionResponse>(
       HttpType.Post,
       "/user/mention/mark_as_read",
       form
@@ -914,7 +886,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/replies`
    */
   async getReplies(form: GetReplies) {
-    return await this.wrapper<GetReplies, GetRepliesResponse>(
+    return this.wrapper<GetReplies, GetRepliesResponse>(
       HttpType.Get,
       "/user/replies",
       form
@@ -927,7 +899,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/ban`
    */
   async banPerson(form: BanPerson) {
-    return await this.wrapper<BanPerson, BanPersonResponse>(
+    return this.wrapper<BanPerson, BanPersonResponse>(
       HttpType.Post,
       "/user/ban",
       form
@@ -940,7 +912,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/banned`
    */
   async getBannedPersons(form: GetBannedPersons) {
-    return await this.wrapper<GetBannedPersons, BannedPersonsResponse>(
+    return this.wrapper<GetBannedPersons, BannedPersonsResponse>(
       HttpType.Get,
       "/user/banned",
       form
@@ -953,7 +925,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/block`
    */
   async blockPerson(form: BlockPerson) {
-    return await this.wrapper<BlockPerson, BlockPersonResponse>(
+    return this.wrapper<BlockPerson, BlockPersonResponse>(
       HttpType.Post,
       "/user/block",
       form
@@ -966,7 +938,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/get_captcha`
    */
   async getCaptcha() {
-    return await this.wrapper<any, GetCaptchaResponse>(
+    return this.wrapper<any, GetCaptchaResponse>(
       HttpType.Get,
       "/user/get_captcha",
       {}
@@ -979,7 +951,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/delete_account`
    */
   async deleteAccount(form: DeleteAccount) {
-    return await this.wrapper<DeleteAccount, DeleteAccountResponse>(
+    return this.wrapper<DeleteAccount, DeleteAccountResponse>(
       HttpType.Post,
       "/user/delete_account",
       form
@@ -992,7 +964,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/password_reset`
    */
   async passwordReset(form: PasswordReset) {
-    return await this.wrapper<PasswordReset, PasswordResetResponse>(
+    return this.wrapper<PasswordReset, PasswordResetResponse>(
       HttpType.Post,
       "/user/password_reset",
       form
@@ -1005,7 +977,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/password_change`
    */
   async passwordChange(form: PasswordChange) {
-    return await this.wrapper<PasswordChange, LoginResponse>(
+    return this.wrapper<PasswordChange, LoginResponse>(
       HttpType.Post,
       "/user/password_change",
       form
@@ -1018,7 +990,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/mark_all_as_read`
    */
   async markAllAsRead(form: MarkAllAsRead) {
-    return await this.wrapper<MarkAllAsRead, GetRepliesResponse>(
+    return this.wrapper<MarkAllAsRead, GetRepliesResponse>(
       HttpType.Post,
       "/user/mark_all_as_read",
       form
@@ -1031,7 +1003,7 @@ export class LemmyHttp {
    * `HTTP.PUT /user/save_user_settings`
    */
   async saveUserSettings(form: SaveUserSettings) {
-    return await this.wrapper<SaveUserSettings, LoginResponse>(
+    return this.wrapper<SaveUserSettings, LoginResponse>(
       HttpType.Put,
       "/user/save_user_settings",
       form
@@ -1044,7 +1016,7 @@ export class LemmyHttp {
    * `HTTP.PUT /user/change_password`
    */
   async changePassword(form: ChangePassword) {
-    return await this.wrapper<ChangePassword, LoginResponse>(
+    return this.wrapper<ChangePassword, LoginResponse>(
       HttpType.Put,
       "/user/change_password",
       form
@@ -1057,7 +1029,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/report_count`
    */
   async getReportCount(form: GetReportCount) {
-    return await this.wrapper<GetReportCount, GetReportCountResponse>(
+    return this.wrapper<GetReportCount, GetReportCountResponse>(
       HttpType.Get,
       "/user/report_count",
       form
@@ -1070,7 +1042,7 @@ export class LemmyHttp {
    * `HTTP.GET /user/unread_count`
    */
   async getUnreadCount(form: GetUnreadCount) {
-    return await this.wrapper<GetUnreadCount, GetUnreadCountResponse>(
+    return this.wrapper<GetUnreadCount, GetUnreadCountResponse>(
       HttpType.Get,
       "/user/unread_count",
       form
@@ -1083,7 +1055,7 @@ export class LemmyHttp {
    * `HTTP.POST /user/verify_email`
    */
   async verifyEmail(form: VerifyEmail) {
-    return await this.wrapper<VerifyEmail, VerifyEmailResponse>(
+    return this.wrapper<VerifyEmail, VerifyEmailResponse>(
       HttpType.Post,
       "/user/verify_email",
       form
@@ -1096,7 +1068,7 @@ export class LemmyHttp {
    * `HTTP.POST /admin/add`
    */
   async addAdmin(form: AddAdmin) {
-    return await this.wrapper<AddAdmin, AddAdminResponse>(
+    return this.wrapper<AddAdmin, AddAdminResponse>(
       HttpType.Post,
       "/admin/add",
       form
@@ -1111,7 +1083,7 @@ export class LemmyHttp {
   async getUnreadRegistrationApplicationCount(
     form: GetUnreadRegistrationApplicationCount
   ) {
-    return await this.wrapper<
+    return this.wrapper<
       GetUnreadRegistrationApplicationCount,
       GetUnreadRegistrationApplicationCountResponse
     >(HttpType.Get, "/admin/registration_application/count", form);
@@ -1123,7 +1095,7 @@ export class LemmyHttp {
    * `HTTP.GET /admin/registration_application/list`
    */
   async listRegistrationApplications(form: ListRegistrationApplications) {
-    return await this.wrapper<
+    return this.wrapper<
       ListRegistrationApplications,
       ListRegistrationApplicationsResponse
     >(HttpType.Get, "/admin/registration_application/list", form);
@@ -1135,7 +1107,7 @@ export class LemmyHttp {
    * `HTTP.PUT /admin/registration_application/approve`
    */
   async approveRegistrationApplication(form: ApproveRegistrationApplication) {
-    return await this.wrapper<
+    return this.wrapper<
       ApproveRegistrationApplication,
       RegistrationApplicationResponse
     >(HttpType.Put, "/admin/registration_application/approve", form);
@@ -1147,7 +1119,7 @@ export class LemmyHttp {
    * `HTTP.POST /admin/purge/person`
    */
   async purgePerson(form: PurgePerson) {
-    return await this.wrapper<PurgePerson, PurgeItemResponse>(
+    return this.wrapper<PurgePerson, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/person",
       form
@@ -1160,7 +1132,7 @@ export class LemmyHttp {
    * `HTTP.POST /admin/purge/community`
    */
   async purgeCommunity(form: PurgeCommunity) {
-    return await this.wrapper<PurgeCommunity, PurgeItemResponse>(
+    return this.wrapper<PurgeCommunity, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/community",
       form
@@ -1173,7 +1145,7 @@ export class LemmyHttp {
    * `HTTP.POST /admin/purge/post`
    */
   async purgePost(form: PurgePost) {
-    return await this.wrapper<PurgePost, PurgeItemResponse>(
+    return this.wrapper<PurgePost, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/post",
       form
@@ -1186,7 +1158,7 @@ export class LemmyHttp {
    * `HTTP.POST /admin/purge/comment`
    */
   async purgeComment(form: PurgeComment) {
-    return await this.wrapper<PurgeComment, PurgeItemResponse>(
+    return this.wrapper<PurgeComment, PurgeItemResponse>(
       HttpType.Post,
       "/admin/purge/comment",
       form

--- a/src/http.ts
+++ b/src/http.ts
@@ -1165,6 +1165,9 @@ export class LemmyHttp {
     );
   }
 
+  /**
+   * Upload an image to the server.
+   */
   async uploadImage({
     image,
     auth,

--- a/src/interfaces/others.ts
+++ b/src/interfaces/others.ts
@@ -230,3 +230,26 @@ export interface SiteMetadata {
   image?: string;
   html?: string;
 }
+
+export interface UploadImage {
+  image: Blob | Buffer;
+  /**
+   * Optional if cookie with jwt set is already present. Otherwise, auth is required.
+   */
+  auth?: string;
+}
+
+export interface UploadImageResponse {
+  /**
+   * Is "ok" if the upload was successful; is something else otherwise.
+   */
+  msg: string;
+  files: ImageFile[];
+  url?: string;
+  delete_url?: string;
+}
+
+export interface ImageFile {
+  file: string;
+  delete_token: string;
+}

--- a/src/interfaces/others.ts
+++ b/src/interfaces/others.ts
@@ -232,7 +232,7 @@ export interface SiteMetadata {
 }
 
 export interface UploadImage {
-  image: Blob | Buffer;
+  image: File | Buffer;
   /**
    * Optional if cookie with jwt set is already present. Otherwise, auth is required.
    */

--- a/src/interfaces/others.ts
+++ b/src/interfaces/others.ts
@@ -244,7 +244,7 @@ export interface UploadImageResponse {
    * Is "ok" if the upload was successful; is something else otherwise.
    */
   msg: string;
-  files: ImageFile[];
+  files?: ImageFile[];
   url?: string;
   delete_url?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,0 @@
-/**
- * Used to prevent typescript from turning dynamic imports into requires when using esm dependencies.
- * See [See this GitHub discussion for more info](https://github.com/TypeStrong/ts-node/discussions/1290).
- */
-export const dynamicImport = new Function(
-  "specifier",
-  "return import(specifier)"
-);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Used to prevent typescript from turning dynamic imports into requires when using esm dependencies.
+ * See [See this GitHub discussion for more info](https://github.com/TypeStrong/ts-node/discussions/1290).
+ */
+export const dynamicImport = new Function(
+  "specifier",
+  "return import(specifier)"
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,9 @@
     "target": "ES5",
     "experimentalDecorators": true,
     "strictNullChecks": true,
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "esModuleInterop": true
   },
-  "include": [
-    "src/**/*"
-  ],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,14 +303,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
-"@types/node-fetch@2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
-  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
 "@types/node@*", "@types/node@^18.6.2":
   version "18.11.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
@@ -490,11 +482,6 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -633,13 +620,6 @@ colorette@^2.0.19:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 commander@^9.4.1:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
@@ -674,6 +654,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -685,11 +670,6 @@ deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-indent@^6.0.0:
   version "6.1.0"
@@ -943,6 +923,14 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -988,14 +976,12 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
   dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
+    fetch-blob "^3.1.2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1459,18 +1445,6 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-mime-types@^2.1.12:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -1513,12 +1487,19 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-fetch@2.6.6:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
+node-fetch@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.1.tgz#b3eea7b54b3a48020e46f4f88b9c5a7430d20b2e"
+  integrity sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==
   dependencies:
-    whatwg-url "^5.0.0"
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-releases@^2.0.6:
   version "2.0.8"
@@ -1962,11 +1943,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -2065,18 +2041,10 @@ vscode-textmate@5.2.0:
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
   integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
+web-streams-polyfill@^3.0.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 which@^2.0.1:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,6 +482,11 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -620,6 +625,13 @@ colorette@^2.0.19:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^9.4.1:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
@@ -645,6 +657,13 @@ cosmiconfig@^5.0.5:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -653,11 +672,6 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-data-uri-to-buffer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
-  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -670,6 +684,11 @@ deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-indent@^6.0.0:
   version "6.1.0"
@@ -923,14 +942,6 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
-  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -976,12 +987,14 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
-    fetch-blob "^3.1.2"
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1445,6 +1458,18 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -1487,19 +1512,12 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
-node-fetch@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.1.tgz#b3eea7b54b3a48020e46f4f88b9c5a7430d20b2e"
-  integrity sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
+    whatwg-url "^5.0.0"
 
 node-releases@^2.0.6:
   version "2.0.8"
@@ -1943,6 +1961,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -2041,10 +2064,18 @@ vscode-textmate@5.2.0:
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
   integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
-web-streams-polyfill@^3.0.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
-  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
This is a PR to take care of #107.

Besides implementing image uploading on the HTTP client, I also updated `node-fetch` to the latest v3.x version. 
To get around the ESM-only module constraint, I followed some advice in the package's docs.

From [`node-fetch`'s docs:](https://www.npmjs.com/package/node-fetch)

> Alternatively, you can use the async import() function from CommonJS to load node-fetch asynchronously:
> ```javascript
> // mod.cjs
> const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
> ```

Since the Typescript compiler turns dynamic imports into requires if the module option in tsconfig.json is set to CommonJS (like this project), a little bit of trickery was required to get the import working properly. That weirdness is a small function in utils.ts with a link in a doc comment to more information on how the trick works.

A side benefit of using the dynamic import for `node-fetch` is that it shouldn't be included in js in the browser since it will use the browser's implementation of `fetch` and the `File` class.