### PR TITLE
Add getComment to client

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -9,6 +9,7 @@ import {
   CreateCommentReport,
   DeleteComment,
   EditComment,
+  GetComment,
   GetComments,
   GetCommentsResponse,
   ListCommentReports,
@@ -669,6 +670,19 @@ export class LemmyHttp {
     return this.wrapper<GetComments, GetCommentsResponse>(
       HttpType.Get,
       "/comment/list",
+      form
+    );
+  }
+
+  /**
+   * Get / fetch comment.
+   *
+   * `HTTP.GET /comment`
+   */
+  getComment(form: GetComment) {
+    return this.wrapper<GetComment, CommentResponse>(
+      HttpType.Get,
+      "/comment",
       form
     );
   }

--- a/src/interfaces/api/comment.ts
+++ b/src/interfaces/api/comment.ts
@@ -92,6 +92,11 @@ export interface GetCommentsResponse {
   comments: CommentView[];
 }
 
+export interface GetComment {
+  id: number;
+  auth?: string;
+}
+
 export interface CreateCommentReport {
   comment_id: number;
   reason: string;

--- a/src/interfaces/others.ts
+++ b/src/interfaces/others.ts
@@ -67,6 +67,7 @@ export enum UserOperation {
   GetPrivateMessages,
   UserJoin,
   GetComments,
+  GetComment,
   PostJoin,
   CommunityJoin,
   ChangePassword,

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -4,6 +4,7 @@ import {
   CreateCommentReport,
   DeleteComment,
   EditComment,
+  GetComment,
   GetComments,
   ListCommentReports,
   RemoveComment,
@@ -299,6 +300,13 @@ export class LemmyWebsocket {
    */
   getComments(form: GetComments) {
     return wrapper(UserOperation.GetComments, form);
+  }
+
+  /**
+   * Get / fetch comment.
+   */
+  getComment(form: GetComment) {
+    return wrapper(UserOperation.GetComment, form);
   }
 
   /**


### PR DESCRIPTION
I noticed that [get comment is a part of the API](https://github.com/LemmyNet/lemmy/blob/main/crates/api_crud/src/comment/read.rs#L13-L42) but isn't included in the client. This PR adds it to the client.