### PR TITLE
Fix body not serializing because of bigint

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -130,6 +130,11 @@ import { VerifyEmail } from "./types/VerifyEmail";
 import { VerifyEmailResponse } from "./types/VerifyEmailResponse";
 import { UploadImage, UploadImageResponse, VERSION } from "./types/others";
 
+// @ts-ignore
+BigInt.prototype["toJSON"] = function () {
+  return this.toString();
+};
+
 enum HttpType {
   Get = "GET",
   Post = "POST",
@@ -1271,9 +1276,7 @@ export class LemmyHttp {
           "Content-Type": "application/json",
           ...this.headers,
         },
-        body: JSON.stringify(form, (_, val) =>
-          typeof val === "bigint" ? val.toString() : val
-        ),
+        body: JSON.stringify(form),
       });
 
       return await response.json();

--- a/src/http.ts
+++ b/src/http.ts
@@ -1271,7 +1271,9 @@ export class LemmyHttp {
           "Content-Type": "application/json",
           ...this.headers,
         },
-        body: JSON.stringify(form),
+        body: JSON.stringify(form, (_, val) =>
+          typeof val === "bigint" ? val.toString() : val
+        ),
       });
 
       return await response.json();

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -718,7 +718,9 @@ export class LemmyWebsocket {
 }
 
 function wrapper<MessageType>(op: UserOperation, data: MessageType) {
-  let send = JSON.stringify({ op: UserOperation[op], data });
+  let send = JSON.stringify({ op: UserOperation[op], data }, (_, val) =>
+    typeof val === "bigint" ? val.toString() : val
+  );
   return send;
 }
 

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -87,6 +87,11 @@ import { TransferCommunity } from "./types/TransferCommunity";
 import { UserJoin } from "./types/UserJoin";
 import { VerifyEmail } from "./types/VerifyEmail";
 
+// @ts-ignore
+BigInt.prototype["toJSON"] = function () {
+  return this.toString();
+};
+
 /**
  * Helps build lemmy websocket message requests, that you can use in your Websocket sends.
  *
@@ -718,9 +723,7 @@ export class LemmyWebsocket {
 }
 
 function wrapper<MessageType>(op: UserOperation, data: MessageType) {
-  let send = JSON.stringify({ op: UserOperation[op], data }, (_, val) =>
-    typeof val === "bigint" ? val.toString() : val
-  );
+  let send = JSON.stringify({ op: UserOperation[op], data });
   return send;
 }
 


### PR DESCRIPTION
I have a library that's dependent on the js client and it was getting errors because `bigint`s cannot be serialized by `JSON.stringify` by default. This should fix that.