### PR TITLE
Making the http `{"error": "..."}` json into a string exception.

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1289,8 +1289,8 @@ export class LemmyHttp {
 
   private async checkandThrowError(response: Response) {
     if (!response.ok) {
-      let errJson = await response.json();
-      let errString: string = errJson["error"] ?? response.statusText;
+      const errJson = await response.json();
+      const errString: string = errJson["error"] ?? response.statusText;
       throw new Error(errString);
     }
   }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1268,6 +1268,8 @@ export class LemmyHttp {
         headers: this.headers,
       });
 
+      await this.checkandThrowError(response);
+
       return await response.json();
     } else {
       const response = await fetch(this.buildFullUrl(endpoint), {
@@ -1279,7 +1281,17 @@ export class LemmyHttp {
         body: JSON.stringify(form),
       });
 
+      await this.checkandThrowError(response);
+
       return await response.json();
+    }
+  }
+
+  private async checkandThrowError(response: Response) {
+    if (!response.ok) {
+      let errJson = await response.json();
+      let errString: string = errJson["error"] ?? response.statusText;
+      throw new Error(errString);
     }
   }
 }


### PR DESCRIPTION
Currently in the lemmy-ui code (since it uses websocket), we are manually checking `if (msg.error) {...`  . 

In the switch to http tho, it'll be nice to throw an exception not just for connection issues, but for any of those responses as well. 

This solution comes from [here](https://stackoverflow.com/questions/56295606/typescriptor-javascript-fetch-api-async-await-error-handling), which says you must check the `response.ok`, and throw an exception when its not. 

In switching over lemmy-ui to use the HTTP client, I plan to do something like this for failed http requests:

```ts
export function apiWrapper<ResponseType>(
  res: ResponseType
): RequestState<ResponseType> {
  try {
    return {
      state: "success",
      data: res,
    };
  } catch (error) {
    return {
      state: "failed",
      msg: error,
    };
  }
}
```






