### PR TITLE
remove trailing slashes from instance url

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -155,7 +155,7 @@ export class LemmyHttp {
    * @param headers optional headers. Should contain `x-real-ip` and `x-forwarded-for` .
    */
   constructor(baseUrl: string, headers?: { [key: string]: string }) {
-    this.#apiUrl = `${baseUrl}/api/${VERSION}`;
+    this.#apiUrl = `${baseUrl.replace(/\/+$/, "")}/api/${VERSION}`;
     this.#pictrsUrl = `${baseUrl}/pictrs/image`;
 
     if (headers) {


### PR DESCRIPTION
`main` branch rn doesnt care about extra trailing slashes in the instance url, but http servers do, because the request urls ends up lookin like `https://instance.yip//api/v3/blablabla`. this adds some regex (specifically, `/\/+$/`) to grab and remove em.