### PR TITLE
Fix throwing for non-JSON error responses

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1315,13 +1315,21 @@ export class LemmyHttp {
         body: JSON.stringify(form),
       });
     }
-    const json = await response.json();
 
     if (!response.ok) {
-      throw json["error"] ?? response.statusText;
-    } else {
-      return json;
+      let error: string | undefined = undefined;
+      if (response.headers.get("content-type")?.includes("application/json")) {
+        error = await response
+          .json()
+          .then(json => json["error"])
+          .catch(() => undefined);
+      } else {
+        error = await response.text();
+      }
+      throw error || response.statusText;
     }
+
+    return await response.json();
   }
 }
 


### PR DESCRIPTION
The client throws an ambiguous JSON exception when Lemmy responds with a plain text error, e.g. when calling `getPost({ id: 123123123123123 })` which causes a parsing error:

![image](https://github.com/LemmyNet/lemmy-js-client/assets/8463786/a0d69f00-1709-4e79-8ac7-b6d23049198f)

This PR fixes this by throwing the body if the `Content-Type` is not `application/json`, otherwise it behaves normally.

Related Issues:

- https://github.com/LemmyNet/lemmy-js-client/issues/141