### PR TITLE
Handle 413 response on image uploads

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1284,6 +1284,10 @@ export class LemmyHttp {
       },
     });
 
+    if (response.status === 413) {
+      return { msg: "too_large" };
+    }
+
     const responseJson = await response.json();
 
     if (responseJson.msg === "ok") {


### PR DESCRIPTION
Currently, when a server responds with 413 content too large for an image upload, then it breaks Lemmy-ui. This PR adds a special `msg` for the 413 case, which can be handled in the UI.

Related PR in Lemmy-UI: https://github.com/LemmyNet/lemmy-ui/pull/1675