### PR TITLE
Fix MarkPostAsRead, wrong response

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -561,7 +561,7 @@ export class LemmyHttp {
    * `HTTP.POST /post/mark_as_read`
    */
   markPostAsRead(form: MarkPostAsRead) {
-    return this.#wrapper<MarkPostAsRead, PostResponse>(
+    return this.#wrapper<MarkPostAsRead, SuccessResponse>(
       HttpType.Post,
       "/post/mark_as_read",
       form,


### PR DESCRIPTION
This still has the wrong response, 

Unrelated tbh `MarkPostAsRead` Should be now `MarkPostsAsRead` (minor, no strong feelings)

Also the "deprecated" post_id should have been straight up removed, Not sure why this short backwardscompatiblity was kept. It's very easy to change from Single to List. (I treat deprecated stuff in My LemmyApi as removed anyway easier to handle future mappings)