### PR TITLE
Properly handle pictrs delete image response

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1409,7 +1409,7 @@ export class LemmyHttp {
   /**
    * Delete a pictrs image
    */
-  async deleteImage({ token, filename }: DeleteImage): Promise<any> {
+  async deleteImage({ token, filename }: DeleteImage): Promise<boolean> {
     const deleteUrl = `${this.#pictrsUrl}/delete/${token}/${filename}`;
 
     const response = await this.#fetchFunction(deleteUrl, {
@@ -1417,7 +1417,7 @@ export class LemmyHttp {
       headers: this.#headers,
     });
 
-    return await response.json();
+    return (await response.status) == 204;
   }
 
   #buildFullUrl(endpoint: string) {


### PR DESCRIPTION
pict-rs returns an empty response with status 204 No Content for the delete endpoint. Thats why https://github.com/LemmyNet/lemmy/pull/4150 is currently failing as the library expects a valid json response.

https://git.asonix.dog/asonix/pict-rs/src/branch/main/src/lib.rs#L758