### PR TITLE
Fix jsdoc comment for listCommentLikes

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -778,7 +778,7 @@ export class LemmyHttp {
   /**
    * List a comment's likes. Admin-only.
    *
-   * `HTTP.GET //like`
+   * `HTTP.GET /comment/like/list`
    */
   listCommentLikes(form: ListCommentLikes) {
     return this.#wrapper<ListCommentLikes, ListCommentLikesResponse>(

--- a/src/http.ts
+++ b/src/http.ts
@@ -622,7 +622,7 @@ export class LemmyHttp {
   /**
    * List a post's likes. Admin-only.
    *
-   * `HTTP.GET /post/like`
+   * `HTTP.GET /post/like/list`
    */
   listPostLikes(form: ListPostLikes) {
     return this.#wrapper<ListPostLikes, ListPostLikesResponse>(


### PR DESCRIPTION
This endpoint had incorrect jsdoc, I parse this for my openapi3 spec so its important for me, that this is right.