### PR TITLE
Add pacakge manager to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,6 @@
       "style": "module",
       "parser": "typescript"
     }
-  }
+  },
+  "packageManager": "pnpm@8.15.5"
 }


### PR DESCRIPTION
pnpm always aggressively adds the package manager field to package.json if it's not there already. Making a PR to add the field so pnpm will stop.