### PR TITLE
Replace yalc recommendation for instructions to do the same thing with pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,8 @@ let jwt = await client.login(loginForm).jwt;
 
 ## Development
 
-You can use [yalc](https://github.com/wclr/yalc) to develop and test changes locally:
+Use `pnpm add` to develop and test changes locally:
 
 ```
-pnpm i --global add yalc
-
-# Go to lemmy-js-client dir
-yalc publish --push
-
-# Go to your client dir
-yalc add lemmy-js-client
-
-# To do updates, go back to the lemmy-js-client dir
-# This also updates it, in every dir you've added it.
-yalc publish --push
+pnpm add path/to/lemmy-js-client
 ```


### PR DESCRIPTION
`pnpm add` supports adding local dependencies easily. Since this library uses `pnpm` now, `yalc` is unnecessary.