### PR TITLE
Add missing docs for logout endpoint

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1046,6 +1046,11 @@ export class LemmyHttp {
     );
   }
 
+  /**
+   * Invalidate the currently used auth token.
+   *
+   * `HTTP.POST /user/logout`
+   */
   logout() {
     return this.#wrapper<object, SuccessResponse>(
       HttpType.Post,


### PR DESCRIPTION
This is currently missing on https://join-lemmy.org/api/classes/LemmyHttp.html#logout