### PR TITLE
Allow falsey get parameter values

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1547,7 +1547,7 @@ export class LemmyHttp {
 
 function encodeGetParams<BodyType extends object>(p: BodyType): string {
   return Object.entries(p)
-    .filter(kv => !!kv[1])
+    .filter(kv => kv[1] !== undefined && kv[1] !== null)
     .map(kv => kv.map(encodeURIComponent).join("="))
     .join("&");
 }


### PR DESCRIPTION
`0`, `false` and `""` currently become `None` on the server.

Noticed this trying to list comments with `max_depth: 0`.