### PR TITLE
Add support for request abort signal

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -161,6 +161,8 @@ enum HttpType {
   Put = "PUT",
 }
 
+type RequestOptions = Pick<RequestInit, "signal">;
+
 /**
  * Helps build lemmy HTTP requests.
  */
@@ -168,7 +170,7 @@ export class LemmyHttp {
   #apiUrl: string;
   #headers: { [key: string]: string } = {};
   #pictrsUrl: string;
-  #fetchFunction = fetch.bind(globalThis);
+  #fetchFunction: typeof fetch = fetch.bind(globalThis);
 
   /**
    * Generates a new instance of LemmyHttp.
@@ -198,8 +200,13 @@ export class LemmyHttp {
    *
    * `HTTP.GET /site`
    */
-  getSite() {
-    return this.#wrapper<object, GetSiteResponse>(HttpType.Get, "/site", {});
+  getSite(options?: RequestOptions) {
+    return this.#wrapper<object, GetSiteResponse>(
+      HttpType.Get,
+      "/site",
+      {},
+      options,
+    );
   }
 
   /**
@@ -207,11 +214,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /site`
    */
-  createSite(form: CreateSite) {
+  createSite(form: CreateSite, options?: RequestOptions) {
     return this.#wrapper<CreateSite, SiteResponse>(
       HttpType.Post,
       "/site",
       form,
+      options,
     );
   }
 
@@ -220,8 +228,13 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /site`
    */
-  editSite(form: EditSite) {
-    return this.#wrapper<EditSite, SiteResponse>(HttpType.Put, "/site", form);
+  editSite(form: EditSite, options?: RequestOptions) {
+    return this.#wrapper<EditSite, SiteResponse>(
+      HttpType.Put,
+      "/site",
+      form,
+      options,
+    );
   }
 
   /**
@@ -229,11 +242,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/leave_admin`
    */
-  leaveAdmin() {
+  leaveAdmin(options?: RequestOptions) {
     return this.#wrapper<object, GetSiteResponse>(
       HttpType.Post,
       "/user/leave_admin",
       {},
+      options,
     );
   }
 
@@ -244,11 +258,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/totp/generate`
    */
-  generateTotpSecret() {
+  generateTotpSecret(options?: RequestOptions) {
     return this.#wrapper<object, GenerateTotpSecretResponse>(
       HttpType.Post,
       "/user/totp/generate",
       {},
+      options,
     );
   }
 
@@ -258,11 +273,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/export_settings`
    */
-  exportSettings() {
+  exportSettings(options?: RequestOptions) {
     return this.#wrapper<object, string>(
       HttpType.Get,
       "/user/export_settings",
       {},
+      options,
     );
   }
 
@@ -271,11 +287,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/import_settings`
    */
-  importSettings(form: any) {
+  importSettings(form: any, options?: RequestOptions) {
     return this.#wrapper<object, SuccessResponse>(
       HttpType.Post,
       "/user/import_settings",
       form,
+      options,
     );
   }
 
@@ -284,11 +301,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/list_logins`
    */
-  listLogins() {
+  listLogins(options?: RequestOptions) {
     return this.#wrapper<object, LoginToken[]>(
       HttpType.Get,
       "/user/list_logins",
       {},
+      options,
     );
   }
 
@@ -297,11 +315,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/validate_auth`
    */
-  validateAuth() {
+  validateAuth(options?: RequestOptions) {
     return this.#wrapper<object, SuccessResponse>(
       HttpType.Get,
       "/user/validate_auth",
       {},
+      options,
     );
   }
 
@@ -310,11 +329,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /account/list_media`
    */
-  listMedia(form: ListMedia = {}) {
+  listMedia(form: ListMedia = {}, options?: RequestOptions) {
     return this.#wrapper<ListMedia, ListMediaResponse>(
       HttpType.Get,
       "/account/list_media",
       form,
+      options,
     );
   }
 
@@ -323,11 +343,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /admin/list_all_media`
    */
-  listAllMedia(form: ListMedia = {}) {
+  listAllMedia(form: ListMedia = {}, options?: RequestOptions) {
     return this.#wrapper<ListMedia, ListMediaResponse>(
       HttpType.Get,
       "/admin/list_all_media",
       form,
+      options,
     );
   }
 
@@ -340,11 +361,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/totp/update`
    */
-  updateTotp(form: UpdateTotp) {
+  updateTotp(form: UpdateTotp, options?: RequestOptions) {
     return this.#wrapper<UpdateTotp, UpdateTotpResponse>(
       HttpType.Post,
       "/user/totp/update",
       form,
+      options,
     );
   }
 
@@ -353,11 +375,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /modlog`
    */
-  getModlog(form: GetModlog = {}) {
+  getModlog(form: GetModlog = {}, options?: RequestOptions) {
     return this.#wrapper<GetModlog, GetModlogResponse>(
       HttpType.Get,
       "/modlog",
       form,
+      options,
     );
   }
 
@@ -366,8 +389,13 @@ export class LemmyHttp {
    *
    * `HTTP.GET /search`
    */
-  search(form: Search) {
-    return this.#wrapper<Search, SearchResponse>(HttpType.Get, "/search", form);
+  search(form: Search, options?: RequestOptions) {
+    return this.#wrapper<Search, SearchResponse>(
+      HttpType.Get,
+      "/search",
+      form,
+      options,
+    );
   }
 
   /**
@@ -375,11 +403,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /resolve_object`
    */
-  resolveObject(form: ResolveObject) {
+  resolveObject(form: ResolveObject, options?: RequestOptions) {
     return this.#wrapper<ResolveObject, ResolveObjectResponse>(
       HttpType.Get,
       "/resolve_object",
       form,
+      options,
     );
   }
 
@@ -388,11 +417,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community`
    */
-  createCommunity(form: CreateCommunity) {
+  createCommunity(form: CreateCommunity, options?: RequestOptions) {
     return this.#wrapper<CreateCommunity, CommunityResponse>(
       HttpType.Post,
       "/community",
       form,
+      options,
     );
   }
 
@@ -401,11 +431,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /community`
    */
-  getCommunity(form: GetCommunity = {}) {
+  getCommunity(form: GetCommunity = {}, options?: RequestOptions) {
     return this.#wrapper<GetCommunity, GetCommunityResponse>(
       HttpType.Get,
       "/community",
       form,
+      options,
     );
   }
 
@@ -414,11 +445,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /community`
    */
-  editCommunity(form: EditCommunity) {
+  editCommunity(form: EditCommunity, options?: RequestOptions) {
     return this.#wrapper<EditCommunity, CommunityResponse>(
       HttpType.Put,
       "/community",
       form,
+      options,
     );
   }
 
@@ -427,11 +459,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /community/list`
    */
-  listCommunities(form: ListCommunities = {}) {
+  listCommunities(form: ListCommunities = {}, options?: RequestOptions) {
     return this.#wrapper<ListCommunities, ListCommunitiesResponse>(
       HttpType.Get,
       "/community/list",
       form,
+      options,
     );
   }
 
@@ -440,11 +473,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/follow`
    */
-  followCommunity(form: FollowCommunity) {
+  followCommunity(form: FollowCommunity, options?: RequestOptions) {
     return this.#wrapper<FollowCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/follow",
       form,
+      options,
     );
   }
 
@@ -453,11 +487,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/block`
    */
-  blockCommunity(form: BlockCommunity) {
+  blockCommunity(form: BlockCommunity, options?: RequestOptions) {
     return this.#wrapper<BlockCommunity, BlockCommunityResponse>(
       HttpType.Post,
       "/community/block",
       form,
+      options,
     );
   }
 
@@ -466,11 +501,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/delete`
    */
-  deleteCommunity(form: DeleteCommunity) {
+  deleteCommunity(form: DeleteCommunity, options?: RequestOptions) {
     return this.#wrapper<DeleteCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/delete",
       form,
+      options,
     );
   }
 
@@ -479,11 +515,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /community/hide`
    */
-  hideCommunity(form: HideCommunity) {
+  hideCommunity(form: HideCommunity, options?: RequestOptions) {
     return this.#wrapper<HideCommunity, SuccessResponse>(
       HttpType.Put,
       "/community/hide",
       form,
+      options,
     );
   }
 
@@ -492,11 +529,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/remove`
    */
-  removeCommunity(form: RemoveCommunity) {
+  removeCommunity(form: RemoveCommunity, options?: RequestOptions) {
     return this.#wrapper<RemoveCommunity, CommunityResponse>(
       HttpType.Post,
       "/community/remove",
       form,
+      options,
     );
   }
 
@@ -505,11 +543,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/transfer`
    */
-  transferCommunity(form: TransferCommunity) {
+  transferCommunity(form: TransferCommunity, options?: RequestOptions) {
     return this.#wrapper<TransferCommunity, GetCommunityResponse>(
       HttpType.Post,
       "/community/transfer",
       form,
+      options,
     );
   }
 
@@ -518,11 +557,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/ban_user`
    */
-  banFromCommunity(form: BanFromCommunity) {
+  banFromCommunity(form: BanFromCommunity, options?: RequestOptions) {
     return this.#wrapper<BanFromCommunity, BanFromCommunityResponse>(
       HttpType.Post,
       "/community/ban_user",
       form,
+      options,
     );
   }
 
@@ -531,11 +571,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /community/mod`
    */
-  addModToCommunity(form: AddModToCommunity) {
+  addModToCommunity(form: AddModToCommunity, options?: RequestOptions) {
     return this.#wrapper<AddModToCommunity, AddModToCommunityResponse>(
       HttpType.Post,
       "/community/mod",
       form,
+      options,
     );
   }
 
@@ -544,11 +585,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /community/random`
    */
-  getRandomCommunity(form: GetRandomCommunity) {
+  getRandomCommunity(form: GetRandomCommunity, options?: RequestOptions) {
     return this.#wrapper<GetRandomCommunity, CommunityResponse>(
       HttpType.Get,
       "/community/random",
       form,
+      options,
     );
   }
 
@@ -557,11 +599,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post`
    */
-  createPost(form: CreatePost) {
+  createPost(form: CreatePost, options?: RequestOptions) {
     return this.#wrapper<CreatePost, PostResponse>(
       HttpType.Post,
       "/post",
       form,
+      options,
     );
   }
 
@@ -570,8 +613,13 @@ export class LemmyHttp {
    *
    * `HTTP.GET /post`
    */
-  getPost(form: GetPost = {}) {
-    return this.#wrapper<GetPost, GetPostResponse>(HttpType.Get, "/post", form);
+  getPost(form: GetPost = {}, options?: RequestOptions) {
+    return this.#wrapper<GetPost, GetPostResponse>(
+      HttpType.Get,
+      "/post",
+      form,
+      options,
+    );
   }
 
   /**
@@ -579,8 +627,13 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /post`
    */
-  editPost(form: EditPost) {
-    return this.#wrapper<EditPost, PostResponse>(HttpType.Put, "/post", form);
+  editPost(form: EditPost, options?: RequestOptions) {
+    return this.#wrapper<EditPost, PostResponse>(
+      HttpType.Put,
+      "/post",
+      form,
+      options,
+    );
   }
 
   /**
@@ -588,11 +641,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/delete`
    */
-  deletePost(form: DeletePost) {
+  deletePost(form: DeletePost, options?: RequestOptions) {
     return this.#wrapper<DeletePost, PostResponse>(
       HttpType.Post,
       "/post/delete",
       form,
+      options,
     );
   }
 
@@ -601,11 +655,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/remove`
    */
-  removePost(form: RemovePost) {
+  removePost(form: RemovePost, options?: RequestOptions) {
     return this.#wrapper<RemovePost, PostResponse>(
       HttpType.Post,
       "/post/remove",
       form,
+      options,
     );
   }
 
@@ -614,11 +669,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/mark_as_read`
    */
-  markPostAsRead(form: MarkPostAsRead) {
+  markPostAsRead(form: MarkPostAsRead, options?: RequestOptions) {
     return this.#wrapper<MarkPostAsRead, SuccessResponse>(
       HttpType.Post,
       "/post/mark_as_read",
       form,
+      options,
     );
   }
 
@@ -627,11 +683,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/hide`
    */
-  hidePost(form: HidePost) {
+  hidePost(form: HidePost, options?: RequestOptions) {
     return this.#wrapper<HidePost, SuccessResponse>(
       HttpType.Post,
       "/post/hide",
       form,
+      options,
     );
   }
 
@@ -640,11 +697,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/lock`
    */
-  lockPost(form: LockPost) {
+  lockPost(form: LockPost, options?: RequestOptions) {
     return this.#wrapper<LockPost, PostResponse>(
       HttpType.Post,
       "/post/lock",
       form,
+      options,
     );
   }
 
@@ -653,11 +711,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/feature`
    */
-  featurePost(form: FeaturePost) {
+  featurePost(form: FeaturePost, options?: RequestOptions) {
     return this.#wrapper<FeaturePost, PostResponse>(
       HttpType.Post,
       "/post/feature",
       form,
+      options,
     );
   }
 
@@ -666,11 +725,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /post/list`
    */
-  getPosts(form: GetPosts = {}) {
+  getPosts(form: GetPosts = {}, options?: RequestOptions) {
     return this.#wrapper<GetPosts, GetPostsResponse>(
       HttpType.Get,
       "/post/list",
       form,
+      options,
     );
   }
 
@@ -679,11 +739,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/like`
    */
-  likePost(form: CreatePostLike) {
+  likePost(form: CreatePostLike, options?: RequestOptions) {
     return this.#wrapper<CreatePostLike, PostResponse>(
       HttpType.Post,
       "/post/like",
       form,
+      options,
     );
   }
 
@@ -692,11 +753,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /post/like/list`
    */
-  listPostLikes(form: ListPostLikes) {
+  listPostLikes(form: ListPostLikes, options?: RequestOptions) {
     return this.#wrapper<ListPostLikes, ListPostLikesResponse>(
       HttpType.Get,
       "/post/like/list",
       form,
+      options,
     );
   }
 
@@ -705,11 +767,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /post/save`
    */
-  savePost(form: SavePost) {
+  savePost(form: SavePost, options?: RequestOptions) {
     return this.#wrapper<SavePost, PostResponse>(
       HttpType.Put,
       "/post/save",
       form,
+      options,
     );
   }
 
@@ -718,11 +781,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /post/report`
    */
-  createPostReport(form: CreatePostReport) {
+  createPostReport(form: CreatePostReport, options?: RequestOptions) {
     return this.#wrapper<CreatePostReport, PostReportResponse>(
       HttpType.Post,
       "/post/report",
       form,
+      options,
     );
   }
 
@@ -731,11 +795,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /post/report/resolve`
    */
-  resolvePostReport(form: ResolvePostReport) {
+  resolvePostReport(form: ResolvePostReport, options?: RequestOptions) {
     return this.#wrapper<ResolvePostReport, PostReportResponse>(
       HttpType.Put,
       "/post/report/resolve",
       form,
+      options,
     );
   }
 
@@ -744,11 +809,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /post/report/list`
    */
-  listPostReports(form: ListPostReports) {
+  listPostReports(form: ListPostReports, options?: RequestOptions) {
     return this.#wrapper<ListPostReports, ListPostReportsResponse>(
       HttpType.Get,
       "/post/report/list",
       form,
+      options,
     );
   }
 
@@ -757,11 +823,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /post/site_metadata`
    */
-  getSiteMetadata(form: GetSiteMetadata) {
+  getSiteMetadata(form: GetSiteMetadata, options?: RequestOptions) {
     return this.#wrapper<GetSiteMetadata, GetSiteMetadataResponse>(
       HttpType.Get,
       "/post/site_metadata",
       form,
+      options,
     );
   }
 
@@ -770,11 +837,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment`
    */
-  createComment(form: CreateComment) {
+  createComment(form: CreateComment, options?: RequestOptions) {
     return this.#wrapper<CreateComment, CommentResponse>(
       HttpType.Post,
       "/comment",
       form,
+      options,
     );
   }
 
@@ -783,11 +851,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /comment`
    */
-  editComment(form: EditComment) {
+  editComment(form: EditComment, options?: RequestOptions) {
     return this.#wrapper<EditComment, CommentResponse>(
       HttpType.Put,
       "/comment",
       form,
+      options,
     );
   }
 
@@ -796,11 +865,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/delete`
    */
-  deleteComment(form: DeleteComment) {
+  deleteComment(form: DeleteComment, options?: RequestOptions) {
     return this.#wrapper<DeleteComment, CommentResponse>(
       HttpType.Post,
       "/comment/delete",
       form,
+      options,
     );
   }
 
@@ -809,11 +879,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/remove`
    */
-  removeComment(form: RemoveComment) {
+  removeComment(form: RemoveComment, options?: RequestOptions) {
     return this.#wrapper<RemoveComment, CommentResponse>(
       HttpType.Post,
       "/comment/remove",
       form,
+      options,
     );
   }
 
@@ -822,11 +893,15 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/mark_as_read`
    */
-  markCommentReplyAsRead(form: MarkCommentReplyAsRead) {
+  markCommentReplyAsRead(
+    form: MarkCommentReplyAsRead,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<MarkCommentReplyAsRead, CommentReplyResponse>(
       HttpType.Post,
       "/comment/mark_as_read",
       form,
+      options,
     );
   }
 
@@ -835,11 +910,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/like`
    */
-  likeComment(form: CreateCommentLike) {
+  likeComment(form: CreateCommentLike, options?: RequestOptions) {
     return this.#wrapper<CreateCommentLike, CommentResponse>(
       HttpType.Post,
       "/comment/like",
       form,
+      options,
     );
   }
 
@@ -848,11 +924,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /comment/like/list`
    */
-  listCommentLikes(form: ListCommentLikes) {
+  listCommentLikes(form: ListCommentLikes, options?: RequestOptions) {
     return this.#wrapper<ListCommentLikes, ListCommentLikesResponse>(
       HttpType.Get,
       "/comment/like/list",
       form,
+      options,
     );
   }
 
@@ -861,11 +938,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /comment/save`
    */
-  saveComment(form: SaveComment) {
+  saveComment(form: SaveComment, options?: RequestOptions) {
     return this.#wrapper<SaveComment, CommentResponse>(
       HttpType.Put,
       "/comment/save",
       form,
+      options,
     );
   }
 
@@ -874,11 +952,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/distinguish`
    */
-  distinguishComment(form: DistinguishComment) {
+  distinguishComment(form: DistinguishComment, options?: RequestOptions) {
     return this.#wrapper<DistinguishComment, CommentResponse>(
       HttpType.Post,
       "/comment/distinguish",
       form,
+      options,
     );
   }
 
@@ -887,11 +966,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /comment/list`
    */
-  getComments(form: GetComments = {}) {
+  getComments(form: GetComments = {}, options?: RequestOptions) {
     return this.#wrapper<GetComments, GetCommentsResponse>(
       HttpType.Get,
       "/comment/list",
       form,
+      options,
     );
   }
 
@@ -900,11 +980,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /comment`
    */
-  getComment(form: GetComment) {
+  getComment(form: GetComment, options?: RequestOptions) {
     return this.#wrapper<GetComment, CommentResponse>(
       HttpType.Get,
       "/comment",
       form,
+      options,
     );
   }
 
@@ -913,11 +994,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /comment/report`
    */
-  createCommentReport(form: CreateCommentReport) {
+  createCommentReport(form: CreateCommentReport, options?: RequestOptions) {
     return this.#wrapper<CreateCommentReport, CommentReportResponse>(
       HttpType.Post,
       "/comment/report",
       form,
+      options,
     );
   }
 
@@ -926,11 +1008,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /comment/report/resolve`
    */
-  resolveCommentReport(form: ResolveCommentReport) {
+  resolveCommentReport(form: ResolveCommentReport, options?: RequestOptions) {
     return this.#wrapper<ResolveCommentReport, CommentReportResponse>(
       HttpType.Put,
       "/comment/report/resolve",
       form,
+      options,
     );
   }
 
@@ -939,11 +1022,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /comment/report/list`
    */
-  listCommentReports(form: ListCommentReports) {
+  listCommentReports(form: ListCommentReports, options?: RequestOptions) {
     return this.#wrapper<ListCommentReports, ListCommentReportsResponse>(
       HttpType.Get,
       "/comment/report/list",
       form,
+      options,
     );
   }
 
@@ -952,11 +1036,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /private_message/list`
    */
-  getPrivateMessages(form: GetPrivateMessages) {
+  getPrivateMessages(form: GetPrivateMessages, options?: RequestOptions) {
     return this.#wrapper<GetPrivateMessages, PrivateMessagesResponse>(
       HttpType.Get,
       "/private_message/list",
       form,
+      options,
     );
   }
 
@@ -965,11 +1050,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /private_message`
    */
-  createPrivateMessage(form: CreatePrivateMessage) {
+  createPrivateMessage(form: CreatePrivateMessage, options?: RequestOptions) {
     return this.#wrapper<CreatePrivateMessage, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message",
       form,
+      options,
     );
   }
 
@@ -978,11 +1064,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /private_message`
    */
-  editPrivateMessage(form: EditPrivateMessage) {
+  editPrivateMessage(form: EditPrivateMessage, options?: RequestOptions) {
     return this.#wrapper<EditPrivateMessage, PrivateMessageResponse>(
       HttpType.Put,
       "/private_message",
       form,
+      options,
     );
   }
 
@@ -991,11 +1078,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /private_message/delete`
    */
-  deletePrivateMessage(form: DeletePrivateMessage) {
+  deletePrivateMessage(form: DeletePrivateMessage, options?: RequestOptions) {
     return this.#wrapper<DeletePrivateMessage, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message/delete",
       form,
+      options,
     );
   }
 
@@ -1004,11 +1092,15 @@ export class LemmyHttp {
    *
    * `HTTP.POST /private_message/mark_as_read`
    */
-  markPrivateMessageAsRead(form: MarkPrivateMessageAsRead) {
+  markPrivateMessageAsRead(
+    form: MarkPrivateMessageAsRead,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<MarkPrivateMessageAsRead, PrivateMessageResponse>(
       HttpType.Post,
       "/private_message/mark_as_read",
       form,
+      options,
     );
   }
 
@@ -1017,11 +1109,14 @@ export class LemmyHttp {
    *
    * `HTTP.POST /private_message/report`
    */
-  createPrivateMessageReport(form: CreatePrivateMessageReport) {
+  createPrivateMessageReport(
+    form: CreatePrivateMessageReport,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<
       CreatePrivateMessageReport,
       PrivateMessageReportResponse
-    >(HttpType.Post, "/private_message/report", form);
+    >(HttpType.Post, "/private_message/report", form, options);
   }
 
   /**
@@ -1029,11 +1124,14 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /private_message/report/resolve`
    */
-  resolvePrivateMessageReport(form: ResolvePrivateMessageReport) {
+  resolvePrivateMessageReport(
+    form: ResolvePrivateMessageReport,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<
       ResolvePrivateMessageReport,
       PrivateMessageReportResponse
-    >(HttpType.Put, "/private_message/report/resolve", form);
+    >(HttpType.Put, "/private_message/report/resolve", form, options);
   }
 
   /**
@@ -1041,11 +1139,14 @@ export class LemmyHttp {
    *
    * `HTTP.GET /private_message/report/list`
    */
-  listPrivateMessageReports(form: ListPrivateMessageReports) {
+  listPrivateMessageReports(
+    form: ListPrivateMessageReports,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<
       ListPrivateMessageReports,
       ListPrivateMessageReportsResponse
-    >(HttpType.Get, "/private_message/report/list", form);
+    >(HttpType.Get, "/private_message/report/list", form, options);
   }
 
   /**
@@ -1053,11 +1154,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/register`
    */
-  register(form: Register) {
+  register(form: Register, options?: RequestOptions) {
     return this.#wrapper<Register, LoginResponse>(
       HttpType.Post,
       "/user/register",
       form,
+      options,
     );
   }
 
@@ -1066,11 +1168,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/login`
    */
-  login(form: Login) {
+  login(form: Login, options?: RequestOptions) {
     return this.#wrapper<Login, LoginResponse>(
       HttpType.Post,
       "/user/login",
       form,
+      options,
     );
   }
 
@@ -1079,11 +1182,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/logout`
    */
-  logout() {
+  logout(options?: RequestOptions) {
     return this.#wrapper<object, SuccessResponse>(
       HttpType.Post,
       "/user/logout",
       {},
+      options,
     );
   }
 
@@ -1092,11 +1196,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user`
    */
-  getPersonDetails(form: GetPersonDetails = {}) {
+  getPersonDetails(form: GetPersonDetails = {}, options?: RequestOptions) {
     return this.#wrapper<GetPersonDetails, GetPersonDetailsResponse>(
       HttpType.Get,
       "/user",
       form,
+      options,
     );
   }
 
@@ -1105,11 +1210,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/mention`
    */
-  getPersonMentions(form: GetPersonMentions) {
+  getPersonMentions(form: GetPersonMentions, options?: RequestOptions) {
     return this.#wrapper<GetPersonMentions, GetPersonMentionsResponse>(
       HttpType.Get,
       "/user/mention",
       form,
+      options,
     );
   }
 
@@ -1118,11 +1224,15 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/mention/mark_as_read`
    */
-  markPersonMentionAsRead(form: MarkPersonMentionAsRead) {
+  markPersonMentionAsRead(
+    form: MarkPersonMentionAsRead,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<MarkPersonMentionAsRead, PersonMentionResponse>(
       HttpType.Post,
       "/user/mention/mark_as_read",
       form,
+      options,
     );
   }
 
@@ -1131,11 +1241,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/replies`
    */
-  getReplies(form: GetReplies) {
+  getReplies(form: GetReplies, options?: RequestOptions) {
     return this.#wrapper<GetReplies, GetRepliesResponse>(
       HttpType.Get,
       "/user/replies",
       form,
+      options,
     );
   }
 
@@ -1144,11 +1255,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/ban`
    */
-  banPerson(form: BanPerson) {
+  banPerson(form: BanPerson, options?: RequestOptions) {
     return this.#wrapper<BanPerson, BanPersonResponse>(
       HttpType.Post,
       "/user/ban",
       form,
+      options,
     );
   }
 
@@ -1157,11 +1269,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/banned`
    */
-  getBannedPersons() {
+  getBannedPersons(options?: RequestOptions) {
     return this.#wrapper<object, BannedPersonsResponse>(
       HttpType.Get,
       "/user/banned",
       {},
+      options,
     );
   }
 
@@ -1170,11 +1283,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/block`
    */
-  blockPerson(form: BlockPerson) {
+  blockPerson(form: BlockPerson, options?: RequestOptions) {
     return this.#wrapper<BlockPerson, BlockPersonResponse>(
       HttpType.Post,
       "/user/block",
       form,
+      options,
     );
   }
 
@@ -1183,11 +1297,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/get_captcha`
    */
-  getCaptcha() {
+  getCaptcha(options?: RequestOptions) {
     return this.#wrapper<object, GetCaptchaResponse>(
       HttpType.Get,
       "/user/get_captcha",
       {},
+      options,
     );
   }
 
@@ -1196,11 +1311,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/delete_account`
    */
-  deleteAccount(form: DeleteAccount) {
+  deleteAccount(form: DeleteAccount, options?: RequestOptions) {
     return this.#wrapper<DeleteAccount, SuccessResponse>(
       HttpType.Post,
       "/user/delete_account",
       form,
+      options,
     );
   }
 
@@ -1209,11 +1325,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/password_reset`
    */
-  passwordReset(form: PasswordReset) {
+  passwordReset(form: PasswordReset, options?: RequestOptions) {
     return this.#wrapper<PasswordReset, SuccessResponse>(
       HttpType.Post,
       "/user/password_reset",
       form,
+      options,
     );
   }
 
@@ -1222,11 +1339,15 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/password_change`
    */
-  passwordChangeAfterReset(form: PasswordChangeAfterReset) {
+  passwordChangeAfterReset(
+    form: PasswordChangeAfterReset,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<PasswordChangeAfterReset, SuccessResponse>(
       HttpType.Post,
       "/user/password_change",
       form,
+      options,
     );
   }
 
@@ -1235,11 +1356,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/mark_all_as_read`
    */
-  markAllAsRead() {
+  markAllAsRead(options?: RequestOptions) {
     return this.#wrapper<object, GetRepliesResponse>(
       HttpType.Post,
       "/user/mark_all_as_read",
       {},
+      options,
     );
   }
 
@@ -1248,11 +1370,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /user/save_user_settings`
    */
-  saveUserSettings(form: SaveUserSettings) {
+  saveUserSettings(form: SaveUserSettings, options?: RequestOptions) {
     return this.#wrapper<SaveUserSettings, SuccessResponse>(
       HttpType.Put,
       "/user/save_user_settings",
       form,
+      options,
     );
   }
 
@@ -1261,11 +1384,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /user/change_password`
    */
-  changePassword(form: ChangePassword) {
+  changePassword(form: ChangePassword, options?: RequestOptions) {
     return this.#wrapper<ChangePassword, LoginResponse>(
       HttpType.Put,
       "/user/change_password",
       form,
+      options,
     );
   }
 
@@ -1274,11 +1398,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/report_count`
    */
-  getReportCount(form: GetReportCount) {
+  getReportCount(form: GetReportCount, options?: RequestOptions) {
     return this.#wrapper<GetReportCount, GetReportCountResponse>(
       HttpType.Get,
       "/user/report_count",
       form,
+      options,
     );
   }
 
@@ -1287,11 +1412,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /user/unread_count`
    */
-  getUnreadCount() {
+  getUnreadCount(options?: RequestOptions) {
     return this.#wrapper<object, GetUnreadCountResponse>(
       HttpType.Get,
       "/user/unread_count",
       {},
+      options,
     );
   }
 
@@ -1300,11 +1426,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /user/verify_email`
    */
-  verifyEmail(form: VerifyEmail) {
+  verifyEmail(form: VerifyEmail, options?: RequestOptions) {
     return this.#wrapper<VerifyEmail, SuccessResponse>(
       HttpType.Post,
       "/user/verify_email",
       form,
+      options,
     );
   }
 
@@ -1313,11 +1440,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/add`
    */
-  addAdmin(form: AddAdmin) {
+  addAdmin(form: AddAdmin, options?: RequestOptions) {
     return this.#wrapper<AddAdmin, AddAdminResponse>(
       HttpType.Post,
       "/admin/add",
       form,
+      options,
     );
   }
 
@@ -1326,11 +1454,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /admin/registration_application/count`
    */
-  getUnreadRegistrationApplicationCount() {
+  getUnreadRegistrationApplicationCount(options?: RequestOptions) {
     return this.#wrapper<object, GetUnreadRegistrationApplicationCountResponse>(
       HttpType.Get,
       "/admin/registration_application/count",
       {},
+      options,
     );
   }
 
@@ -1339,11 +1468,14 @@ export class LemmyHttp {
    *
    * `HTTP.GET /admin/registration_application/list`
    */
-  listRegistrationApplications(form: ListRegistrationApplications) {
+  listRegistrationApplications(
+    form: ListRegistrationApplications,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<
       ListRegistrationApplications,
       ListRegistrationApplicationsResponse
-    >(HttpType.Get, "/admin/registration_application/list", form);
+    >(HttpType.Get, "/admin/registration_application/list", form, options);
   }
 
   /**
@@ -1351,11 +1483,14 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /admin/registration_application/approve`
    */
-  approveRegistrationApplication(form: ApproveRegistrationApplication) {
+  approveRegistrationApplication(
+    form: ApproveRegistrationApplication,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<
       ApproveRegistrationApplication,
       RegistrationApplicationResponse
-    >(HttpType.Put, "/admin/registration_application/approve", form);
+    >(HttpType.Put, "/admin/registration_application/approve", form, options);
   }
 
   /**
@@ -1363,11 +1498,14 @@ export class LemmyHttp {
    *
    * `HTTP.GET /admin/registration_application`
    */
-  getRegistrationApplication(form: GetRegistrationApplication) {
+  getRegistrationApplication(
+    form: GetRegistrationApplication,
+    options?: RequestOptions,
+  ) {
     return this.#wrapper<
       GetRegistrationApplication,
       RegistrationApplicationResponse
-    >(HttpType.Get, "/admin/registration_application", form);
+    >(HttpType.Get, "/admin/registration_application", form, options);
   }
 
   /**
@@ -1375,11 +1513,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/purge/person`
    */
-  purgePerson(form: PurgePerson) {
+  purgePerson(form: PurgePerson, options?: RequestOptions) {
     return this.#wrapper<PurgePerson, SuccessResponse>(
       HttpType.Post,
       "/admin/purge/person",
       form,
+      options,
     );
   }
 
@@ -1388,11 +1527,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/purge/community`
    */
-  purgeCommunity(form: PurgeCommunity) {
+  purgeCommunity(form: PurgeCommunity, options?: RequestOptions) {
     return this.#wrapper<PurgeCommunity, SuccessResponse>(
       HttpType.Post,
       "/admin/purge/community",
       form,
+      options,
     );
   }
 
@@ -1401,11 +1541,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/purge/post`
    */
-  purgePost(form: PurgePost) {
+  purgePost(form: PurgePost, options?: RequestOptions) {
     return this.#wrapper<PurgePost, SuccessResponse>(
       HttpType.Post,
       "/admin/purge/post",
       form,
+      options,
     );
   }
 
@@ -1414,11 +1555,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/purge/comment`
    */
-  purgeComment(form: PurgeComment) {
+  purgeComment(form: PurgeComment, options?: RequestOptions) {
     return this.#wrapper<PurgeComment, SuccessResponse>(
       HttpType.Post,
       "/admin/purge/comment",
       form,
+      options,
     );
   }
 
@@ -1427,11 +1569,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /custom_emoji`
    */
-  createCustomEmoji(form: CreateCustomEmoji) {
+  createCustomEmoji(form: CreateCustomEmoji, options?: RequestOptions) {
     return this.#wrapper<CreateCustomEmoji, CustomEmojiResponse>(
       HttpType.Post,
       "/custom_emoji",
       form,
+      options,
     );
   }
 
@@ -1440,11 +1583,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /custom_emoji`
    */
-  editCustomEmoji(form: EditCustomEmoji) {
+  editCustomEmoji(form: EditCustomEmoji, options?: RequestOptions) {
     return this.#wrapper<EditCustomEmoji, CustomEmojiResponse>(
       HttpType.Put,
       "/custom_emoji",
       form,
+      options,
     );
   }
 
@@ -1453,11 +1597,12 @@ export class LemmyHttp {
    *
    * `HTTP.Post /custom_emoji/delete`
    */
-  deleteCustomEmoji(form: DeleteCustomEmoji) {
+  deleteCustomEmoji(form: DeleteCustomEmoji, options?: RequestOptions) {
     return this.#wrapper<DeleteCustomEmoji, SuccessResponse>(
       HttpType.Post,
       "/custom_emoji/delete",
       form,
+      options,
     );
   }
 
@@ -1466,11 +1611,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /custom_emoji/list`
    */
-  listCustomEmojis(form: ListCustomEmojis) {
+  listCustomEmojis(form: ListCustomEmojis, options?: RequestOptions) {
     return this.#wrapper<ListCustomEmojis, ListCustomEmojisResponse>(
       HttpType.Get,
       "/custom_emoji/list",
       form,
+      options,
     );
   }
 
@@ -1479,11 +1625,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /admin/tagline`
    */
-  createTagline(form: CreateTagline) {
+  createTagline(form: CreateTagline, options?: RequestOptions) {
     return this.#wrapper<CreateTagline, TaglineResponse>(
       HttpType.Post,
       "/admin/tagline",
       form,
+      options,
     );
   }
 
@@ -1492,11 +1639,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /admin/tagline`
    */
-  editTagline(form: UpdateTagline) {
+  editTagline(form: UpdateTagline, options?: RequestOptions) {
     return this.#wrapper<UpdateTagline, TaglineResponse>(
       HttpType.Put,
       "/admin/tagline",
       form,
+      options,
     );
   }
 
@@ -1505,11 +1653,12 @@ export class LemmyHttp {
    *
    * `HTTP.Post /admin/tagline/delete`
    */
-  deleteTagline(form: DeleteTagline) {
+  deleteTagline(form: DeleteTagline, options?: RequestOptions) {
     return this.#wrapper<DeleteTagline, SuccessResponse>(
       HttpType.Post,
       "/admin/tagline/delete",
       form,
+      options,
     );
   }
 
@@ -1518,11 +1667,12 @@ export class LemmyHttp {
    *
    * `HTTP.GET /admin/tagline/list`
    */
-  listTaglines(form: ListTaglines) {
+  listTaglines(form: ListTaglines, options?: RequestOptions) {
     return this.#wrapper<ListTaglines, ListTaglinesResponse>(
       HttpType.Get,
       "/admin/tagline/list",
       form,
+      options,
     );
   }
 
@@ -1531,11 +1681,12 @@ export class LemmyHttp {
    *
    * `HTTP.POST /oauth_provider`
    */
-  createOAuthProvider(form: CreateOAuthProvider) {
+  createOAuthProvider(form: CreateOAuthProvider, options?: RequestOptions) {
     return this.#wrapper<CreateOAuthProvider, OAuthProvider>(
       HttpType.Post,
       "/oauth_provider",
       form,
+      options,
     );
   }
 
@@ -1544,11 +1695,12 @@ export class LemmyHttp {
    *
    * `HTTP.PUT /oauth_provider`
    */
-  editOAuthProvider(form: EditOAuthProvider) {
+  editOAuthProvider(form: EditOAuthProvider, options?: RequestOptions) {
     return this.#wrapper<EditOAuthProvider, OAuthProvider>(
       HttpType.Put,
       "/oauth_provider",
       form,
+      options,
     );
   }
 
@@ -1557,11 +1709,12 @@ export class LemmyHttp {
    *
    * `HTTP.Post /oauth_provider/delete`
    */
-  deleteOAuthProvider(form: DeleteOAuthProvider) {
+  deleteOAuthProvider(form: DeleteOAuthProvider, options?: RequestOptions) {
     return this.#wrapper<DeleteOAuthProvider, SuccessResponse>(
       HttpType.Post,
       "/oauth_provider/delete",
       form,
+      options,
     );
   }
 
@@ -1570,11 +1723,12 @@ export class LemmyHttp {
    *
    * `HTTP.Post /oauth/authenticate`
    */
-  authenticateWithOAuth(form: AuthenticateWithOauth) {
+  authenticateWithOAuth(form: AuthenticateWithOauth, options?: RequestOptions) {
     return this.#wrapper<AuthenticateWithOauth, LoginResponse>(
       HttpType.Post,
       "/oauth/authenticate",
       form,
+      options,
     );
   }
 
@@ -1583,11 +1737,12 @@ export class LemmyHttp {
    *
    * `HTTP.Get /federated_instances`
    */
-  getFederatedInstances() {
+  getFederatedInstances(options?: RequestOptions) {
     return this.#wrapper<object, GetFederatedInstancesResponse>(
       HttpType.Get,
       "/federated_instances",
       {},
+      options,
     );
   }
 
@@ -1596,24 +1751,29 @@ export class LemmyHttp {
    *
    * `HTTP.Post /site/block`
    */
-  blockInstance(form: BlockInstance) {
+  blockInstance(form: BlockInstance, options?: RequestOptions) {
     return this.#wrapper<BlockInstance, BlockInstanceResponse>(
       HttpType.Post,
       "/site/block",
       form,
+      options,
     );
   }
 
   /**
    * Upload an image to the server.
    */
-  async uploadImage({ image }: UploadImage): Promise<UploadImageResponse> {
+  async uploadImage(
+    { image }: UploadImage,
+    options?: RequestOptions,
+  ): Promise<UploadImageResponse> {
     const formData = createFormData(image);
 
     let url: string | undefined = undefined;
     let delete_url: string | undefined = undefined;
 
     const response = await this.#fetchFunction(this.#pictrsUrl, {
+      ...options,
       method: HttpType.Post,
       body: formData as unknown as BodyInit,
       headers: this.#headers,
@@ -1641,10 +1801,14 @@ export class LemmyHttp {
   /**
    * Delete a pictrs image
    */
-  async deleteImage({ token, filename }: DeleteImage): Promise<boolean> {
+  async deleteImage(
+    { token, filename }: DeleteImage,
+    options?: RequestOptions,
+  ): Promise<boolean> {
     const deleteUrl = `${this.#pictrsUrl}/delete/${token}/${filename}`;
 
     const response = await this.#fetchFunction(deleteUrl, {
+      ...options,
       method: HttpType.Get,
       headers: this.#headers,
     });
@@ -1660,16 +1824,19 @@ export class LemmyHttp {
     type_: HttpType,
     endpoint: string,
     form: BodyType,
+    options: RequestOptions | undefined,
   ): Promise<ResponseType> {
     let response: Response;
     if (type_ === HttpType.Get) {
       const getUrl = `${this.#buildFullUrl(endpoint)}?${encodeGetParams(form)}`;
       response = await this.#fetchFunction(getUrl, {
+        ...options,
         method: HttpType.Get,
         headers: this.#headers,
       });
     } else {
       response = await this.#fetchFunction(this.#buildFullUrl(endpoint), {
+        ...options,
         method: type_,
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
This PR adds support for aborting requests. This is best practice to promptly clean up asyncronous requests as e.g. components are unmounted.

`AbortController` is supported in all modern browsers, and all currently supported Node versions (Node 18 is currently minimum LTS version, `AbortController` added in Node 15) - https://nodejs.org/en/about/previous-releases

This PR requires no code changes for end users. Abortable requests is entirely optional.

https://developer.mozilla.org/en-US/docs/Web/API/AbortController

https://dev.to/viclafouch/cancel-properly-http-requests-in-react-hooks-and-avoid-memory-leaks-pd7