### PR TITLE
Adds Server endpoints to the spec

### DIFF
--- a/tsoa.json
+++ b/tsoa.json
@@ -1,7 +1,9 @@
 {
   "entryFile": "src/http.ts",
   "noImplicitAdditionalProperties": "throw-on-extras",
-  "controllerPathGlobs": ["src/http.ts"],
+  "controllerPathGlobs": [
+    "src/http.ts"
+  ],
   "spec": {
     "outputDirectory": "tsoa_build",
     "specVersion": 3,
@@ -11,6 +13,34 @@
         "scheme": "bearer",
         "bearerFormat": "JWT"
       }
+    },
+    "spec": {
+      "servers": [
+        {
+          "url": "https://voyager.lemmy.ml",
+          "description": "Lemmy Voyager: Testing environment"
+        },
+        {
+          "url": "https://ds9.lemmy.ml",
+          "description": "Lemmy ds9: Testing environment"
+        },
+        {
+          "url": "https://enterprise.lemmy.ml",
+          "description": "Lemmy Enterprise: Testing environment"
+        },
+        {
+          "url": "http://localhost:8888",
+          "description": "Local testing environment"
+        },
+        {
+          "url": "https://lemmy.ml",
+          "description": "Lemmy.ml"
+        },
+        {
+          "url": "https://lemmy.world",
+          "description": "Lemmy.world"
+        }
+      ]
     }
   },
   "routes": {

--- a/tsoa.json
+++ b/tsoa.json
@@ -29,7 +29,7 @@
           "description": "Lemmy Enterprise: Testing environment"
         },
         {
-          "url": "http://localhost:8888",
+          "url": "http://localhost:8536",
           "description": "Local testing environment"
         },
         {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5abe72ef-01b8-420c-8b7a-5bb431c7bf9e)

See https://github.com/lukeautry/tsoa/issues/909#issuecomment-786839358

I don't know the difference between ds9/Enterprise/Voyager, so I couldn't specify the distinction.