### PR TITLE
Use @tsoa/runtime imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "type": "git",
     "url": "git+https://github.com/LemmyNet/lemmy-js-client.git"
   },
+  "dependencies": {
+    "@tsoa/runtime": "^6.6.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@redocly/cli": "^1.27.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@tsoa/runtime':
+        specifier: ^6.6.0
+        version: 6.6.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.20.0

--- a/src/http.ts
+++ b/src/http.ts
@@ -11,7 +11,7 @@ import {
   Delete,
   Security,
   Tags,
-} from "tsoa";
+} from "@tsoa/runtime";
 import {
   DeleteImageParamsI,
   GetCommentI,


### PR DESCRIPTION
Webpack tries to import node stuff from "@tsoa/cli" when importing "tsoa".