### PR TITLE
Log http errors

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -2939,7 +2939,7 @@ export class LemmyHttp extends Controller {
     }
 
     if (!response.ok) {
-      console.log(
+      console.error(
         `Request error while calling ${type_} ${endpoint} with ${form}`,
       );
       let err = new LemmyError(json.error ?? response.statusText, json.message);


### PR DESCRIPTION
Currently getting an error on lemmy-ui homepage which doesnt show anything useful. With this it should be better.
```
not_found
at LemmyHttp._LemmyHttp_wrapper (/home/felix/workspace/lemmy/lemmy-ui/node_modules/.pnpm/lemmy-js-client@1.0.0-community-post-notifs.0/node_modules/lemmy-js-client/dist/http.js:1021:19)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```