### PR TITLE
Format error file before regex

### DIFF
--- a/scripts/copy_generated_types_from_lemmy.sh
+++ b/scripts/copy_generated_types_from_lemmy.sh
@@ -43,6 +43,7 @@ find src/types -type f -name '*.ts' -exec sed -i 's/bigint/number/g' {} +
 # find src/types -type f -name '*.ts' -exec sed -i '' -e 's/bigint/number/g' {} \;
 
 # Parse LemmyErrorType and convert it to array.
+pnpm prettier -w src/types/LemmyErrorType.ts
 ALL_ERRORS=$(cat src/types/LemmyErrorType.ts | \
 perl -nle 'm/\{ \s*error:\s*"(.*?)" \}/; print $1' | \
 sed '/^[[:space:]]*$/d'| \


### PR DESCRIPTION
I was testing with the beginning of this file commented out, so it already started with `LemmyErrorType.ts` correctly formatted. But when generating things from scratch it would be unformatted and the regex wouldnt match. So it needs an explicit format call.