### PR TITLE
RequestState wrapper from lemmy-ui (fixes #921)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.7.0"
   },
+  "exports": {
+    ".": "./dist/index.js",
+    "./wrapper/*": "./dist/wrapper/*.js"
+  },
   "packageManager": "pnpm@10.33.2",
   "types": "./dist/index.d.ts",
   "lint-staged": {

--- a/src/wrapper/request_state.ts
+++ b/src/wrapper/request_state.ts
@@ -1,0 +1,46 @@
+import { LemmyHttp } from "../http";
+import { ApiKey, wrapLemmyClient } from "./wrapper";
+
+export const EMPTY_REQUEST = { state: "empty" } as const;
+export type EmptyRequestState = typeof EMPTY_REQUEST;
+
+export const LOADING_REQUEST = { state: "loading" } as const;
+export type LoadingRequestState = typeof LOADING_REQUEST;
+
+export type FailedRequestState = { state: "failed"; err: Error };
+
+export type SuccessRequestState<T> = { state: "success"; data: T };
+
+/**
+ * Shows the state of an API request.
+ *
+ * Can be empty, loading, failed, or success
+ */
+export type RequestState<T> =
+  | EmptyRequestState
+  | LoadingRequestState
+  | FailedRequestState
+  | SuccessRequestState<T>;
+
+function mapToRequestState<ResultT>(
+  result?: ResultT,
+  error?: Error,
+): RequestState<ResultT> {
+  if (error) {
+    return { state: "failed", err: error };
+  }
+  if (result !== undefined) {
+    return { state: "success", data: result };
+  }
+  return { state: "empty" };
+}
+
+type RequestStateApi = {
+  [K in ApiKey]: typeof mapToRequestState<Awaited<ReturnType<LemmyHttp[K]>>>;
+};
+
+export function wrapClient(client: LemmyHttp) {
+  return wrapLemmyClient<RequestStateApi>(client, mapToRequestState);
+}
+
+export type WrappedLemmyHttp = ReturnType<typeof wrapClient>;

--- a/src/wrapper/wrapper.ts
+++ b/src/wrapper/wrapper.ts
@@ -1,0 +1,117 @@
+import { LemmyHttp } from "../http";
+
+const UNMAPPED_KEYS = [
+  "upload",
+  "uploadWithQuery",
+  "wrapper",
+  "setHeaders",
+  "setStatus",
+  "getStatus",
+  "setHeader",
+  "getHeader",
+  "getHeaders",
+] as const;
+
+const unmappedSet = new Set<keyof LemmyHttp>(UNMAPPED_KEYS);
+
+type UnmappedKey = (typeof UNMAPPED_KEYS)[number];
+
+type VoidKey = {
+  [K in keyof LemmyHttp]: LemmyHttp[K] extends CallableFunction
+    ? LemmyHttp[K] extends () => void | undefined
+      ? K
+      : LemmyHttp[K] extends () => Promise<void | undefined>
+        ? K
+        : never
+    : never;
+}[keyof LemmyHttp];
+
+// Assert that all void functions are included in UNMAPPED_KEYS
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+(voidKey: VoidKey) => {
+  return { unmappedKey: voidKey } as {
+    unmappedKey: UnmappedKey;
+  };
+};
+
+export type ApiKey = {
+  [K in keyof LemmyHttp]: LemmyHttp[K] extends CallableFunction
+    ? K extends UnmappedKey
+      ? never // unmapped
+      : K
+    : never; // property
+}[keyof LemmyHttp];
+
+type ApiMap = {
+  [K in ApiKey]: (
+    this: void,
+    result?: Awaited<ReturnType<LemmyHttp[K]>>,
+    error?: Error,
+  ) => unknown;
+};
+
+type MapFn<Map extends ApiMap> = {
+  [K in keyof ApiMap]: Map[K];
+}[keyof ApiMap];
+
+export type WrappedLemmyHttp<Map extends ApiMap> = {
+  client: LemmyHttp;
+  mapFn: MapFn<Map>;
+  new (client: LemmyHttp, mapFn: MapFn<Map>): WrappedLemmyHttp<Map>;
+} & {
+  readonly [K in keyof LemmyHttp]: K extends keyof ApiMap
+    ? (...args: Parameters<LemmyHttp[K]>) => Promise<ReturnType<Map[K]>>
+    : // unmapped or property
+      LemmyHttp[K];
+};
+
+const handler: ProxyHandler<WrappedLemmyHttp<ApiMap>> = {
+  get(target: WrappedLemmyHttp<ApiMap>, p: keyof LemmyHttp) {
+    const value = target.client[p];
+    if (typeof value !== "function") {
+      return value;
+    }
+
+    const func: LemmyHttp[UnmappedKey | ApiKey] = value;
+
+    if (unmappedSet.has(p)) {
+      return (...args: unknown[]) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
+        return func.apply<any, any[], any>(target.client, args);
+      };
+    }
+
+    return async (...args: unknown[]) => {
+      try {
+        return target.mapFn(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+          await func.apply<any, any[], any>(target.client, args),
+        );
+      } catch (err) {
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        const error = err instanceof Error ? err : new Error("" + err);
+        return target.mapFn(undefined, error);
+      }
+    };
+  },
+};
+
+function WrappedLemmyHttpImpl<Map extends ApiMap>(
+  this: WrappedLemmyHttp<Map>,
+  client: LemmyHttp,
+  mapFn: MapFn<Map>,
+) {
+  this.client = client;
+  this.mapFn = mapFn;
+  return new Proxy(this, handler);
+}
+
+export function wrapLemmyClient<Map extends ApiMap>(
+  client: LemmyHttp,
+  mapFn: MapFn<Map>,
+) {
+  return new (WrappedLemmyHttpImpl as unknown as WrappedLemmyHttp<Map>)(
+    client,
+    mapFn,
+  );
+}


### PR DESCRIPTION
The implementation is a bit different to the what we had in lemmy-ui. It's using a Proxy and ProxyHandler to forward calls to the client. This approach doesn't require iterating over all keys.

The wrapped client is exported as "lemmy-js-client/wrapper/request_state".