### PR TITLE
Fix request state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lemmy-js-client",
   "description": "A javascript / typescript client for Lemmy",
-  "version": "1.0.0-community-title-optional.0",
+  "version": "1.0.0-fix-request-state.0",
   "author": "Dessalines",
   "license": "AGPL-3.0",
   "main": "./dist/index.js",

--- a/src/http.ts
+++ b/src/http.ts
@@ -249,7 +249,6 @@ class LemmyController extends Controller {
   #apiUrl: string;
   #headers: { [key: string]: string } = {};
   #fetchFunction = fetch.bind(globalThis);
-  #useRequestState: boolean = false;
 
   /**
    * Generates a new instance of LemmyHttp.
@@ -261,7 +260,6 @@ class LemmyController extends Controller {
     options?: {
       fetchFunction?: typeof fetch;
       headers?: { [key: string]: string };
-      useRequestState: boolean;
     },
   ) {
     super();
@@ -272,9 +270,6 @@ class LemmyController extends Controller {
     }
     if (options?.fetchFunction) {
       this.#fetchFunction = options.fetchFunction;
-    }
-    if (options?.useRequestState) {
-      this.#useRequestState = options.useRequestState;
     }
   }
 
@@ -315,7 +310,7 @@ class LemmyController extends Controller {
       // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
       error = err instanceof Error ? err : new Error("" + err);
     }
-    return mapToRequestState(this.#useRequestState, result, error);
+    return mapToRequestState(result, error);
   }
 
   async uploadWithQuery<QueryType extends object, ResponseType>(
@@ -389,7 +384,7 @@ class LemmyController extends Controller {
       error = err instanceof Error ? err : new Error("" + err);
     }
 
-    return mapToRequestState(this.#useRequestState, result, error);
+    return mapToRequestState(result, error);
   }
 
   /**

--- a/src/map_request_state.main.ts
+++ b/src/map_request_state.main.ts
@@ -1,13 +1,9 @@
 import { RequestState } from "./request_state";
 
 export function mapToRequestState<ResultT>(
-  useRequestState: boolean,
   result?: ResultT,
   error?: Error,
-): RequestState<ResultT> | ResultT | undefined {
-  if (!useRequestState) {
-    return result;
-  }
+): RequestState<ResultT> {
   if (error) {
     return { state: "failed", err: error };
   }

--- a/src/map_request_state.ts
+++ b/src/map_request_state.ts
@@ -1,13 +1,9 @@
 import { RequestState } from "./request_state";
 
 export function mapToRequestState<ResultT>(
-  useRequestState: boolean,
   result?: ResultT,
   error?: Error,
-): RequestState<ResultT> | ResultT | undefined {
-  if (!useRequestState) {
-    return result;
-  }
+): RequestState<ResultT> {
   if (error) {
     return { state: "failed", err: error };
   }


### PR DESCRIPTION
Lemmy-ui couldn't handle my union type. 

It doesn't really matter, because your fix already rewrites the tsoa function so that it returns the bare type, and not `RequestState` . That's all we really cared about.

This removes the pointless optional `useRequestState`.