### PR TITLE
fix: use correct /account/invite/list path

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -3073,7 +3073,7 @@ export class LemmyHttp extends LemmyController {
   ) {
     return this.wrapper<ListInvitationsI, PagedResponse<LocalUserInvite>>(
       HttpType.Get,
-      "/account/invite",
+      "/account/invite/list",
       form,
       options,
     );


### PR DESCRIPTION
## Summary
- The `listRegistrationInvitations` method uses `@Get("/account/invite/list")` decorator but the actual wrapper call uses `/account/invite` (wrong). This fixes it to use `/account/invite/list` to match the backend route.

Needed for lemmy-ui PR #4298.